### PR TITLE
Add spec

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,7 @@
+{
+    "src_file": "index.bs",
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
+}

--- a/index.bs
+++ b/index.bs
@@ -1,0 +1,17 @@
+<pre class='metadata'>
+Title: Cookie-Store
+Shortname: cookiestore
+Level: 1
+Status: LD
+Group: cookie-store
+Repository: WICG/cookie-store
+URL: https://github.com/WICG/cookie-store
+Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
+Abstract: An asynchronous Javascript cookies API for documents and workers
+</pre>
+
+Introduction {#intro}
+=====================
+
+Introduction here.
+

--- a/index.bs
+++ b/index.bs
@@ -7,11 +7,317 @@ Group: cookie-store
 Repository: WICG/cookie-store
 URL: https://github.com/WICG/cookie-store
 Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
+Markup Shorthands: markdown yes
 Abstract: An asynchronous Javascript cookies API for documents and workers
 </pre>
 
-Introduction {#intro}
-=====================
+<h2 id="intro">
+Introduction</h2>
 
-Introduction here.
+This is a proposal to bring an asynchronous cookie API to scripts running in HTML documents and [service workers](https://github.com/slightlyoff/ServiceWorker).
 
+[HTTP cookies](https://tools.ietf.org/html/rfc6265) have, since their origins at Netscape [(documentation preserved by archive.org)](https://web.archive.org/web/0/http://wp.netscape.com/newsref/std/cookie_spec.html), provided a [valuable state-management mechanism](http://www.montulli-blog.com/2013/05/the-reasoning-behind-web-cookies.html) for the web. 
+
+The synchronous single-threaded script-level `document.cookie` and `<meta http-equiv="set-cookie" ...>` interface to cookies has been a source of [complexity and performance woes](https://lists.w3.org/Archives/Public/public-whatwg-archive/2009Sep/0083.html) further exacerbated by the move in many browsers from:
+  - a single browser process,
+  - a single-threaded event loop model, and
+  - no general expectation of responsiveness for scripted event handling while processing cookie operations
+
+... to the modern web which strives for smoothly responsive high performance:
+  - in multiple browser processes,
+  - with a multithreaded, multiple-event loop model, and
+  - with an expectation of responsiveness on human-reflex time scales.
+
+On the modern web a cookie operation in one part of a web application cannot block:
+  - the rest of the web application,
+  - the rest of the web origin, or
+  - the browser as a whole.
+
+Newer parts of the web built in service workers [need access to cookies too](https://github.com/slightlyoff/ServiceWorker/issues/707) but cannot use the synchronous, blocking `document.cookie` and `<meta http-equiv="set-cookie" ...>` interfaces at all as they both have no `document` and also cannot block the event loop as that would interfere with handling of unrelated events.
+
+<h3 id="intro-proposed-change>
+A Taste of the Proposed Change
+</h3>
+
+Although it is tempting to [rethink cookies](https://discourse.wicg.io/t/rethinking-cookies/744) entirely, web sites today continue to rely heavily on them, and the script APIs for using them are largely unchanged over their first decades of usage.
+
+Today writing a cookie means blocking your event loop while waiting for the browser to synchronously update the cookie jar with a carefully-crafted cookie string in `Set-Cookie` format:
+
+```js
+document.cookie =
+  '__Secure-COOKIENAME=cookie-value' +
+  '; Path=/' +
+  '; expires=Fri, 12 Aug 2016 23:05:17 GMT' +
+  '; Secure' +
+  '; Domain=example.org';
+// now we could assume the write succeeded, but since
+// failure is silent it is difficult to tell, so we
+// read to see whether the write succeeded
+var successRegExp =
+  /(^|; ?)__Secure-COOKIENAME=cookie-value(;|$)/;
+if (String(document.cookie).match(successRegExp)) {
+  console.log('It worked!');
+} else {
+  console.error('It did not work, and we do not know why');
+}
+```
+
+What if you could instead write:
+
+```js
+cookieStore.set(
+  '__Secure-COOKIENAME',
+  'cookie-value',
+  {
+    expires: Date.now() + 24*60*60*1000,
+    domain: 'example.org'
+  }).then(function() {
+    console.log('It worked!');
+  }, function(reason) {
+    console.error(
+      'It did not work, and this is why:',
+      reason);
+  });
+// Meanwhile we can do other things while waiting for
+// the cookie store to process the write...
+```
+
+This also has the advantage of not relying on `document` and not blocking, which together make it usable from [service workers](https://github.com/slightlyoff/ServiceWorker), which otherwise do not have cookie access from script.
+
+This proposal also includes a power-efficient monitoring API to replace `setTimeout`-based polling cookie monitors with cookie change observers.
+
+<h3 id="intro-summary">
+Summary
+</h3>
+
+This proposal outlines an asynchronous API using Promises/async functions for the following cookie operations:
+
+	* [write](#writing) (or "set") cookies
+	* [delete](#clearing) (or "expire") cookies
+	* [read](#reading) (or "get") [script-visible](#script-visibility) cookies
+		* ... including for specified in-scope request paths in
+			[service worker](https://github.com/slightlyoff/ServiceWorker) contexts
+	* [monitor](#monitoring) [script-visible](#script-visibility) cookies for changes
+		* ... [using `CookieObserver`](#single-execution-context) in long-running script contexts (e.g. `document`)
+		* ... [using `CookieChangeEvent`](#service-worker) after registration during the `InstallEvent`
+			in ephemeral [service worker](https://github.com/slightlyoff/ServiceWorker) contexts
+		* ... again including for script-supplied in-scope request paths
+			in [service worker](https://github.com/slightlyoff/ServiceWorker) contexts
+
+<h4 id="script-visibility">
+Script visibility
+</h4>
+
+A cookie is script-visible when it is in-scope and does not have the `HttpOnly` cookie flag.
+
+<h4 id="intro-motivation">
+Motivations
+</h4>
+
+Some service workers [need access to cookies](https://github.com/slightlyoff/ServiceWorker/issues/707) but
+cannot use the synchronous, blocking `document.cookie` interface as they both have no `document` and
+also cannot block the event loop as that would interfere with handling of unrelated events.
+
+A new API may also provide a rare and valuable chance to address
+some [outstanding cross-browser incompatibilities](https://github.com/inikulin/cookie-compat) and bring [divergent
+specs and user-agent behavior](https://github.com/whatwg/html/issues/804) into closer correspondence.
+
+A well-designed and opinionated API may actually make cookies easier to deal with correctly from
+scripts, with the potential effect of reducing their accidental misuse. An efficient monitoring API, in particular,
+can be used to replace power-hungry polling cookie scanners.
+
+The API must interoperate well enough with existing cookie APIs (HTTP-level, HTML-level and script-level) that it can be adopted incrementally by a large or complex website.
+
+<h4 id="intro-opinions">
+Opinions
+</h4>
+
+This API defaults cookie paths to `/` for cookie write operations, including deletion/expiration. The implicit relative path-scoping of cookies to `.` has caused a lot of additional complexity for relatively little gain given their security equivalence under the same-origin policy and the difficulties arising from multiple same-named cookies at overlapping paths on the same domain. Cookie paths without a trailing `/` are treated as if they had a trailing `/` appended for cookie write operations. Cookie paths must start with `/` for write operations, and must not contain any `..` path segments. Query parameters and URL fragments are not allowed in paths for cookie write operations.
+
+URLs without a trailing `/` are treated as if the final path segment had been removed for cookie read operations, including change monitoring. Paths for cookie read operations are resolved relative to the default read cookie path.
+
+This API defaults cookies to "Secure" when they are written from a secure web origin. This is intended to prevent unintentional leakage to unsecured connections on the same domain. Furthermore it disallows (to the extent permitted by the browser implementation) [creation or modification of `Secure`-flagged cookies from unsecured web origins](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-alone-00) and [enforces special rules for the `__Host-` and `__Secure-` cookie name prefixes](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00).
+
+This API defaults cookies to "Domain"-less, which in conjunction with "Secure" provides origin-scoped cookie
+behavior in most modern browsers. When practical the [`__Host-` cookie name prefix](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00) should be used with these cookies so that cooperating browsers origin-scope them.
+
+Serialization of expiration times for non-session cookies in a special cookie-specific format has proven cumbersome,
+so this API allows JavaScript Date objects and numeric timestamps (milliseconds since the beginning of the Unix epoch) to be used instead. The inconsistently-implemented Max-Age parameter is not exposed, although similar functionality is available for the specific case of expiring a cookie.
+
+Cookies without `=` in their HTTP Cookie header serialization are treated as having an empty name, consistent with the majority of current browsers. Cookies with an empty name cannot be set using values containing `=` as this would result in ambiguous serializations in the majority of current browsers.
+
+Internationalized cookie usage from scripts has to date been slow and browser-specific due to lack of interoperability because although several major browsers use UTF-8 interpretation for cookie data, historically Safari and browsers based on WinINet have not. This API mandates UTF-8 interpretation for cookies read or written by this API.
+
+Use of cookie-change-driven scripts has been hampered by the absence of a power-efficient (non-polling) API for this. This API provides observers for efficient monitoring in document contexts and interest registration for efficient monitoring in service worker contexts.
+
+Scripts should not have to write and then read "test cookies" to determine whether script-initiated cookie write access is possible, nor should they have to correlate with cooperating server-side versions of the same write-then-read test to determine that script-initiated cookie read access is impossible despite cookies working at the HTTP level.
+
+<h4 id="intro-compat">
+Compatiblity
+</h4>
+
+Some user-agents implement non-standard extensions to cookie behavior. The intent of this specification,
+though, is to first capture a useful and interoperable (or mostly-interoperable) subset of cookie behavior implemented
+across modern browsers. As new cookie features are specified and adopted it is expected that this API will be
+extended to include them. A secondary goal is to converge with `document.cookie` behavior, `<meta http-equiv=set-cookie>`,
+and the http cookie specification. See https://github.com/whatwg/html/issues/804 and https://inikulin.github.io/cookie-compat/
+for the current state of this convergence.
+
+Differences across browsers in how bytes outside the printable-ASCII subset are interpreted has led to
+long-lasting user- and developer-visible incompatibilities across browsers making internationalized use of cookies
+needlessly cumbersome. This API requires UTF-8 interpretation of cookie data and uses `USVString` for the script interface,
+with the additional side-effects that subsequent uses of `document.cookie` to read a cookie read or written through this interface and subsequent uses of `document.cookie` or
+`<meta http-equiv=set-cookie>` to update a cookie previously read or written through this interface will also use a UTF-8 interpretation of the cookie data. In practice this
+will change the behavior of `WinINet`-based user agents and Safari but should bring their behavior into concordance
+with other modern user agents.
+
+<h2 id="api">
+The API</h2>
+
+<h3 id="CookieStore">
+The {{CookieStore}} Interface</h3>
+
+<xmp class="idl">
+[
+  Exposed=(ServiceWorker,Window),
+  RuntimeEnabled=AsyncCookies
+] interface CookieStore : EventTarget {
+  [RaisesException] Promise<CookieList?> getAll(
+      USVString name, optional CookieStoreGetOptions options);
+  [RaisesException] Promise<CookieList?> getAll(
+      optional CookieStoreGetOptions options);
+  [RaisesException] Promise<CookieListItem?> get(
+      USVString name, optional CookieStoreGetOptions options);
+  [RaisesException] Promise<CookieListItem?> get(
+      optional CookieStoreGetOptions options);
+  [RaisesException] Promise<boolean> has(
+      USVString name, optional CookieStoreGetOptions options);
+  [RaisesException] Promise<boolean> has(
+      optional CookieStoreGetOptions options);
+
+  [RaisesException] Promise<void> set(
+      USVString name, USVString value, optional CookieStoreSetOptions options);
+  [RaisesException] Promise<void> set(
+      CookieStoreSetOptions options);
+
+  [RaisesException] Promise<void> delete(
+      USVString name, optional CookieStoreSetOptions options);
+  [RaisesException] Promise<void> delete(
+      CookieStoreSetOptions options);
+
+  attribute EventHandler onchange;
+};
+</xmp>
+
+<h4 id="CookieStore-attributes">
+Attributes</h4>
+
+<dl dfn-type=attribute dfn-for=CookieStore>
+	: <dfn>onchange</dfn>
+	::
+		Something changed
+</dl>
+
+<h4 id="CookieStore-methods">
+Methods</h4>
+
+<dl dfn-type=method dfn-for="CookieStore">
+	: <dfn>getAll(name, options)</dfn>
+	::
+		Get all the cookies
+
+		<pre class=argumentdef for="CookieStore/getAll(name, options)">
+			name: name
+			options: options
+		</pre>
+	: <dfn>getAll(options)</dfn>
+	::
+		Get all the cookies
+
+		<pre class=argumentdef for="CookieStore/getAll(options)">
+			options: options
+		</pre>
+
+	: <dfn>get(name, options)</dfn>
+	::
+		Get something
+
+		<pre class=argumentdef for="CookieStore/get(name, options)">
+			name: name
+			options: options
+		</pre>
+	: <dfn>get(options)</dfn>
+	::
+		Get something
+
+		<pre class=argumentdef for="CookieStore/get(options)">
+			options: options
+		</pre>
+	: <dfn>has(name, options)</dfn>
+	::
+		Has something
+
+		<pre class=argumentdef for="CookieStore/has(name, options)">
+			name: name
+			options: options
+		</pre>
+	: <dfn>has(options)</dfn>
+	::
+		Has something
+
+		<pre class=argumentdef for="CookieStore/has(options)">
+			options: options
+		</pre>
+	: <dfn>set(name, value, options)</dfn>
+	::
+		Set cookie
+
+		<pre class=argumentdef for="CookieStore/set(name, value, options)">
+			name: name
+		value: value
+		options: options
+		</pre>
+	: <dfn>set(options)</dfn>
+	::
+		Set cookie
+
+		<pre class=argumentdef for="CookieStore/set(options)">
+			options: options
+		</pre>
+	: <dfn>delete(name, options)</dfn>
+	::
+		Delete something
+
+		<pre class=argumentdef for="CookieStore/delete(name, options)">
+			name: name
+			options: options
+		</pre>
+	: <dfn>delete(options)</dfn>
+	::
+		Delete something
+
+		<pre class=argumentdef for="CookieStore/delete(options)">
+			options: options
+		</pre>
+</dl>
+
+<h4 id="CookieStore-options">
+Options</h4>
+
+<h5 id="CookieStore-set-options">
+CookieStoreSetOptions</h5>
+
+<pre class="idl">
+enum CookieMatchType {
+  "equals",
+  "startsWith"
+};
+</pre>
+
+<pre class="idl">
+dictionary CookieStoreGetOptions {
+  USVString name;
+  USVString url;
+  CookieMatchType matchType = "equals";
+};
+</pre>

--- a/index.bs
+++ b/index.bs
@@ -759,7 +759,8 @@ Attributes</h3>
 Security</h2>
 Other than cookie access from service worker contexts, this API is not intended to expose any new capabilities to the web.
 
-### Gotcha!
+<h3 id="gotcha">
+Gotcha!</h3>
 
 Although browser cookie implementations are now evolving in the direction of better security and fewer surprising and error-prone defaults, there are at present few guarantees about cookie data security.
 
@@ -774,11 +775,13 @@ Although browser cookie implementations are now evolving in the direction of bet
 
 For these reasons it is best to use caution when interpreting any cookie's value, and never execute a cookie's value as script, HTML, CSS, XML, PDF, or any other executable format.
 
-### Restrict?
+<h3 id="restrict">
+Restrict?</h3>
 
 This API may have the unintended side-effect of making cookies easier to use and consequently encouraging their further use. If it causes their further use in unsecured `http` contexts this could result in a web less safe for users. For that reason it may be desirable to restrict its use, or at least the use of the `set` and `delete` operations, to secure origins running in secure contexts.
 
-### Surprises
+<h3 id="surprises">
+Surprises</h3>
 
 Some existing cookie behavior (especially domain-rather-than-origin orientation, unsecured contexts being able to set cookies readable in secure contexts, and script being able to set cookies unreadable from script contexts) may be quite surprising from a web security standpoint.
 
@@ -786,19 +789,22 @@ Other surprises are documented in [Section 1 of HTTP State Management Mechanism 
 
 Further complicating this are historical differences in cookie-handling across major browsers, although some of those (e.g. port number handling) are now handled with more consistency than they once were.
 
-### Prefixes
+<h3 id="prefixes">
+Prefixes</h3>
 
 Where feasible the examples use the `__Host-` and `__Secure-` name prefixes from [Cookie Prefixes](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00) which causes some current browsers to disallow overwriting from unsecured contexts, disallow overwriting with no `Secure` flag, and -- in the case of `__Host-` -- disallow overwriting with an explicit `Domain` or non-'/' `Path` attribute (effectively enforcing same-origin semantics.) These prefixes provide important security benefits in those browsers implementing Secure Cookies and degrade gracefully (i.e. the special semantics may not be enforced in other cookie APIs but the cookies work normally and the async cookies API enforces the secure semantics for write operations) in other browsers. A major goal of this API is interoperation with existing cookies, though, so a few examples have also been provided using cookie names lacking these prefixes.
 
 Prefix rules are also enforced in write operations by this API, but may not be enforced in the same browser for other APIs. For this reason it is inadvisable to rely on their enforcement too heavily until and unless they are more broadly adopted.
 
-### URL scoping
+<h3 id="url-scoping">
+URL scoping</h3>
 
 Although a service worker script cannot directly access cookies today, it can already use controlled rendering of in-scope HTML and script resources to inject cookie-monitoring code under the remote control of the service worker script. This means that cookie access inside the scope of the service worker is technically possible already, it's just not very convenient.
 
 When the service worker is scoped more narrowly than `/` it may still be able to read path-scoped cookies from outside its scope's path space by successfully guessing/constructing a 404 page URL which allows IFRAME-ing and then running script inside it the same technique could expand to the whole origin, but a carefully constructed site (one where no out-of-scope pages are IFRAME-able) can actually deny this capability to a path-scoped service worker today and I was reluctant to remove that restriction without further discussion of the implications.
 
-### Cookie aversion
+<h3 id="aversion">
+Cookie aversion</h3>
 
 To reduce complexity for developers and eliminate the need for ephemeral test cookies, this async cookies API will explicitly reject attempts to write or delete cookies when the operation would be ignored. Likewise it will explicitly reject attempts to read cookies when that operation would ignore actual cookie data and simulate an empty cookie jar. Attempts to observe cookie changes in these contexts will still "work", but won't invoke the callback until and unless read access becomes allowed (due e.g. to changed site permissions.)
 

--- a/index.bs
+++ b/index.bs
@@ -177,7 +177,6 @@ The {{CookieStore}} Interface</h2>
 <xmp class="idl">
 [
   Exposed=(ServiceWorker,Window),
-  RuntimeEnabled=AsyncCookies
 ] interface CookieStore : EventTarget {
   [RaisesException] Promise<CookieList?> getAll(
       USVString name, optional CookieStoreGetOptions options);

--- a/index.bs
+++ b/index.bs
@@ -171,11 +171,8 @@ with the additional side-effects that subsequent uses of `document.cookie` to re
 will change the behavior of `WinINet`-based user agents and Safari but should bring their behavior into concordance
 with other modern user agents.
 
-<h2 id="api">
-The API</h2>
-
-<h3 id="CookieStore">
-The {{CookieStore}} Interface</h3>
+<h2 id="CookieStore">
+The {{CookieStore}} Interface</h2>
 
 <xmp class="idl">
 [
@@ -209,8 +206,8 @@ The {{CookieStore}} Interface</h3>
 };
 </xmp>
 
-<h4 id="CookieStore-attributes">
-Attributes</h4>
+<h3 id="CookieStore-attributes">
+Attributes</h3>
 
 <dl dfn-type=attribute dfn-for=CookieStore>
 	: <dfn>onchange</dfn>
@@ -218,8 +215,8 @@ Attributes</h4>
 		Something changed
 </dl>
 
-<h4 id="CookieStore-methods">
-Methods</h4>
+<h3 id="CookieStore-methods">
+Methods</h3>
 
 <dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>getAll(name, options)</dfn>
@@ -301,11 +298,11 @@ Methods</h4>
 		</pre>
 </dl>
 
-<h4 id="CookieStore-options">
-Options</h4>
+<h3 id="CookieStore-options">
+Options</h3>
 
-<h5 dictionary lt="CookieStoreGetOptions">
-{{CookieStoreGetOptions}}</h5>
+<h4 dictionary lt="CookieStoreGetOptions">
+{{CookieStoreGetOptions}}</h4>
 
 <pre class="idl">
 enum CookieMatchType {
@@ -322,8 +319,8 @@ dictionary CookieStoreGetOptions {
 };
 </pre>
 
-<h6 id="dictionary-get-options-members">
-Dictionary {{CookieStoreGetOptions}} Members</h6>
+<h5 id="dictionary-get-options-members">
+Dictionary {{CookieStoreGetOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="CookieStoreGetOptions">
 	: <dfn>name</dfn>
@@ -336,8 +333,8 @@ Dictionary {{CookieStoreGetOptions}} Members</h6>
 	:: how to match a cookie
 </dl>
 
-<h5 dictionary lt="CookieStoreSetOptions">
-{{CookieStoreSetOptions}}</h5>
+<h4 dictionary lt="CookieStoreSetOptions">
+{{CookieStoreSetOptions}}</h4>
 
 <pre class="idl">
 dictionary CookieStoreSetOptions {
@@ -351,8 +348,8 @@ dictionary CookieStoreSetOptions {
 };
 </pre>
 
-<h6 id="dictionary-set-options-members">
-Dictionary {{CookieStoreSetOptions}} Members</h6>
+<h5 id="dictionary-set-options-members">
+Dictionary {{CookieStoreSetOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="CookieStoreSetOptions">
 	: <dfn>name</dfn>

--- a/index.bs
+++ b/index.bs
@@ -214,7 +214,7 @@ Attributes</h3>
 <dl dfn-type=attribute dfn-for=CookieStore>
 	: <dfn>onchange</dfn>
 	::
-		Something changed
+		An {{EventHandler}} of type {{CookieChangeEvent}}.
 </dl>
 
 <h3 id="CookieStore-methods">
@@ -671,6 +671,8 @@ Dictionary {{CookieListItem}} Members</h5>
 <h4 id="CookieChangeEvent">
 The {{CookieChangeEvent}} Interface</h4>
 
+This is an {{Event}} object which is dispatched to {{CookieStore}}.
+
 <pre class="idl">
 [
   Exposed=(ServiceWorker,Window),
@@ -723,6 +725,17 @@ partial interface ServiceWorkerGlobalScope {
 };
 </pre>
 
+<h3 id="ServiceWorkerCookieStore-attributes">
+Attributes</h3>
+<h4 id="ServiceWorkerCookieStore-attributes-cookiestore">
+{{ServiceWorkerGlobalScope/cookieStore}}</h4>
+
+<dl dfn-type=attribute dfn-for=ServiceWorkerGlobalScope>
+	: <dfn>cookieStore</dfn>
+	:: Cookie store a {{ServiceWorker}}
+</dl>
+
+
 <h2 id="WindowCookieStore">
 The WindowCookieStore Interface</h2>
 
@@ -732,3 +745,63 @@ partial interface Window {
 };
 </pre>
 
+<h3 id="WindowCookieStore-attributes">
+Attributes</h3>
+<h4 id="WindowCookieStore-attributes-cookiestore">
+{{Window/cookieStore}}</h4>
+
+<dl dfn-type=attribute dfn-for=Window>
+	: <dfn>cookieStore</dfn>
+	:: Cookie store a {{Window}}
+</dl>
+
+<h2 id="Security">
+Security</h2>
+Other than cookie access from service worker contexts, this API is not intended to expose any new capabilities to the web.
+
+### Gotcha!
+
+Although browser cookie implementations are now evolving in the direction of better security and fewer surprising and error-prone defaults, there are at present few guarantees about cookie data security.
+
+ * unsecured origins can typically overwrite cookies used on secure origins
+ * superdomains can typically overwrite cookies seen by subdomains
+ * cross-site scripting attacts and other script and header injection attacks can be used to forge cookies too
+ * cookie read operations (both from script and on web servers) don't give any indication of where the cookie came from
+ * browsers sometimes truncate, transform or evict cookie data in surprising and counterintuitive ways
+   * ... due to reaching storage limits
+   * ... due to character encoding differences
+   * ... due to differing syntactic and semantic rules for cookies
+
+For these reasons it is best to use caution when interpreting any cookie's value, and never execute a cookie's value as script, HTML, CSS, XML, PDF, or any other executable format.
+
+### Restrict?
+
+This API may have the unintended side-effect of making cookies easier to use and consequently encouraging their further use. If it causes their further use in unsecured `http` contexts this could result in a web less safe for users. For that reason it may be desirable to restrict its use, or at least the use of the `set` and `delete` operations, to secure origins running in secure contexts.
+
+### Surprises
+
+Some existing cookie behavior (especially domain-rather-than-origin orientation, unsecured contexts being able to set cookies readable in secure contexts, and script being able to set cookies unreadable from script contexts) may be quite surprising from a web security standpoint.
+
+Other surprises are documented in [Section 1 of HTTP State Management Mechanism (RFC 6265)](https://tools.ietf.org/html/rfc6265#section-1) - for instance, a cookie may be set for a superdomain (e.g. app.example.com may set a cookie for the whole example.com domain), and a cookie may be readable across all port numbers on a given domain name.
+
+Further complicating this are historical differences in cookie-handling across major browsers, although some of those (e.g. port number handling) are now handled with more consistency than they once were.
+
+### Prefixes
+
+Where feasible the examples use the `__Host-` and `__Secure-` name prefixes from [Cookie Prefixes](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00) which causes some current browsers to disallow overwriting from unsecured contexts, disallow overwriting with no `Secure` flag, and -- in the case of `__Host-` -- disallow overwriting with an explicit `Domain` or non-'/' `Path` attribute (effectively enforcing same-origin semantics.) These prefixes provide important security benefits in those browsers implementing Secure Cookies and degrade gracefully (i.e. the special semantics may not be enforced in other cookie APIs but the cookies work normally and the async cookies API enforces the secure semantics for write operations) in other browsers. A major goal of this API is interoperation with existing cookies, though, so a few examples have also been provided using cookie names lacking these prefixes.
+
+Prefix rules are also enforced in write operations by this API, but may not be enforced in the same browser for other APIs. For this reason it is inadvisable to rely on their enforcement too heavily until and unless they are more broadly adopted.
+
+### URL scoping
+
+Although a service worker script cannot directly access cookies today, it can already use controlled rendering of in-scope HTML and script resources to inject cookie-monitoring code under the remote control of the service worker script. This means that cookie access inside the scope of the service worker is technically possible already, it's just not very convenient.
+
+When the service worker is scoped more narrowly than `/` it may still be able to read path-scoped cookies from outside its scope's path space by successfully guessing/constructing a 404 page URL which allows IFRAME-ing and then running script inside it the same technique could expand to the whole origin, but a carefully constructed site (one where no out-of-scope pages are IFRAME-able) can actually deny this capability to a path-scoped service worker today and I was reluctant to remove that restriction without further discussion of the implications.
+
+### Cookie aversion
+
+To reduce complexity for developers and eliminate the need for ephemeral test cookies, this async cookies API will explicitly reject attempts to write or delete cookies when the operation would be ignored. Likewise it will explicitly reject attempts to read cookies when that operation would ignore actual cookie data and simulate an empty cookie jar. Attempts to observe cookie changes in these contexts will still "work", but won't invoke the callback until and unless read access becomes allowed (due e.g. to changed site permissions.)
+
+Today writing to `document.cookie` in contexts where script-initiated cookie-writing is disallowed typically is a no-op. However, many cookie-writing scripts and frameworks always write a test cookie and then check for its existence to determine whether script-initiated cookie-writing is possible.
+
+Likewise, today reading `document.cookie` in contexts where script-initiated cookie-reading is disallowed typically returns an empty string. However, a cooperating web server can verify that server-initiated cookie-writing and cookie-reading work and report this to the script (which still sees empty string) and the script can use this information to infer that script-initiated cookie-reading is disallowed.

--- a/index.bs
+++ b/index.bs
@@ -297,8 +297,8 @@ Methods</h3>
 		</pre>
 </dl>
 
-<h3 id="CookieStore-options">
-Options</h3>
+<h3 id="CookieStore-dictionaries">
+Dictinaries</h3>
 
 <h4 dictionary lt="CookieStoreGetOptions">
 {{CookieStoreGetOptions}}</h4>
@@ -373,6 +373,30 @@ Dictionary {{CookieStoreSetOptions}} Members</h5>
 	:: http only
 </dl>
 
+<h4 dictionary lt="CookieItemList">
+{{CookieItemList}}</h4>
+
+<xmp class="idl">
+dictionary CookieListItem {
+  USVString name;
+  USVString value;
+};
+
+typedef sequence<CookieListItem> CookieList;
+</xmp>
+
+<h5 id="dictionary-cookie-list-item-members">
+Dictionary {{CookieListItem}} Members</h5>
+
+<dl dfn-type=dict-member dfn-for="CookieListItem">
+	: <dfn>name</dfn>
+	:: name of cookie
+
+	: <dfn>value</dfn>
+	:: value of cookie
+</dl>
+
+
 <h2 id="ServiceWorkerGlobalScopeCookieStore">
 The ServiceWorkerGlobalScopeCookieStore Interface</h2>
 
@@ -383,7 +407,7 @@ partial interface ServiceWorkerGlobalScope {
 </pre>
 
 <h2 id="WindowCookieStore">
-The {{WindowCookieStore}} Interface</h2>
+The WindowCookieStore Interface</h2>
 
 <pre class="idl">
 partial interface Window {

--- a/index.bs
+++ b/index.bs
@@ -764,14 +764,14 @@ Gotcha!</h3>
 
 Although browser cookie implementations are now evolving in the direction of better security and fewer surprising and error-prone defaults, there are at present few guarantees about cookie data security.
 
- * unsecured origins can typically overwrite cookies used on secure origins
- * superdomains can typically overwrite cookies seen by subdomains
- * cross-site scripting attacts and other script and header injection attacks can be used to forge cookies too
- * cookie read operations (both from script and on web servers) don't give any indication of where the cookie came from
- * browsers sometimes truncate, transform or evict cookie data in surprising and counterintuitive ways
-   * ... due to reaching storage limits
-   * ... due to character encoding differences
-   * ... due to differing syntactic and semantic rules for cookies
+	* unsecured origins can typically overwrite cookies used on secure origins
+	* superdomains can typically overwrite cookies seen by subdomains
+	* cross-site scripting attacts and other script and header injection attacks can be used to forge cookies too
+	* cookie read operations (both from script and on web servers) don't give any indication of where the cookie came from
+	* browsers sometimes truncate, transform or evict cookie data in surprising and counterintuitive ways
+		* ... due to reaching storage limits
+		* ... due to character encoding differences
+		* ... due to differing syntactic and semantic rules for cookies
 
 For these reasons it is best to use caution when interpreting any cookie's value, and never execute a cookie's value as script, HTML, CSS, XML, PDF, or any other executable format.
 

--- a/index.bs
+++ b/index.bs
@@ -304,8 +304,8 @@ Methods</h4>
 <h4 id="CookieStore-options">
 Options</h4>
 
-<h5 id="CookieStore-set-options">
-CookieStoreSetOptions</h5>
+<h5 dictionary lt="CookieStoreGetOptions">
+{{CookieStoreGetOptions}}</h5>
 
 <pre class="idl">
 enum CookieMatchType {
@@ -321,3 +321,59 @@ dictionary CookieStoreGetOptions {
   CookieMatchType matchType = "equals";
 };
 </pre>
+
+<h6 id="dictionary-get-options-members">
+Dictionary {{CookieStoreGetOptions}} Members</h6>
+
+<dl dfn-type=dict-member dfn-for="CookieStoreGetOptions">
+	: <dfn>name</dfn>
+	:: name of cookie
+
+	: <dfn>url</dfn>
+	:: some url
+
+	: <dfn>matchType</dfn>
+	:: how to match a cookie
+</dl>
+
+<h5 dictionary lt="CookieStoreSetOptions">
+{{CookieStoreSetOptions}}</h5>
+
+<pre class="idl">
+dictionary CookieStoreSetOptions {
+  USVString name;
+  USVString value;
+  DOMTimeStamp? expires = null;
+  USVString domain;
+  USVString path = "/";
+  boolean? secure;
+  boolean httpOnly = false;
+};
+</pre>
+
+<h6 id="dictionary-set-options-members">
+Dictionary {{CookieStoreSetOptions}} Members</h6>
+
+<dl dfn-type=dict-member dfn-for="CookieStoreSetOptions">
+	: <dfn>name</dfn>
+	:: name of cookie
+
+	: <dfn>value</dfn>
+	:: value for cookie
+
+	: <dfn>expires</dfn>
+	:: expiration
+
+	: <dfn>domain</dfn>
+	:: domain
+
+	: <dfn>path</dfn>
+	:: path
+
+	: <dfn>secure</dfn>
+	:: secure
+
+	: <dfn>httpOnly</dfn>
+	:: http only
+</dl>
+

--- a/index.bs
+++ b/index.bs
@@ -298,7 +298,7 @@ Methods</h3>
 </dl>
 
 <h3 id="CookieStore-dictionaries">
-Dictinaries</h3>
+Dictionaries</h3>
 
 <h4 dictionary lt="CookieStoreGetOptions">
 {{CookieStoreGetOptions}}</h4>

--- a/index.bs
+++ b/index.bs
@@ -397,6 +397,52 @@ Dictionary {{CookieListItem}} Members</h5>
 </dl>
 
 
+<h4 id="CookieChangeEvent">
+The {{CookieChangeEvent}} Interface</h4>
+
+<pre class="idl">
+[
+  Exposed=(ServiceWorker,Window),
+  Constructor(DOMString type, optional CookieChangeEventInit eventInitDict)
+] interface CookieChangeEvent : Event {
+  readonly attribute CookieList changed;
+  readonly attribute CookieList deleted;
+};
+</pre>
+
+<h5 id="CookieChangeEvent-attributes">
+Attributes</h5>
+
+<dl dfn-type=attribute dfn-for="CookieChangeEvent">
+	: <dfn>changed</dfn>
+	:: changed
+
+	: <dfn>deleted</dfn>
+	:: deleted cookies
+</dl>
+
+<h5 id="CookieChangeEventInit">
+{{CookieChangeEventInit}}</h5>
+
+<pre class="idl">
+dictionary CookieChangeEventInit : EventInit {
+  CookieList changed;
+  CookieList deleted;
+};
+</pre>
+
+<h6 id="CookieChangeEventInit-members">
+{{CookieChangeEventInit}} Members
+</h5>
+<dl dfn-type=dict-member dfn-for="CookieChangeEventInit">
+	: <dfn>changed</dfn>
+	:: changed
+
+	: <dfn>deleted</dfn>
+	:: deleted cookies
+</dl>
+
+
 <h2 id="ServiceWorkerGlobalScopeCookieStore">
 The ServiceWorkerGlobalScopeCookieStore Interface</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -208,6 +208,9 @@ The {{CookieStore}} Interface</h2>
 <h3 id="CookieStore-attributes">
 Attributes</h3>
 
+<h4 id="CookieStore-attributes-onchange">
+{{onchange}}
+</h4>
 <dl dfn-type=attribute dfn-for=CookieStore>
 	: <dfn>onchange</dfn>
 	::
@@ -216,6 +219,9 @@ Attributes</h3>
 
 <h3 id="CookieStore-methods">
 Methods</h3>
+
+<h4 id="CookieStore-methods-getAll">
+{{CookieStore/getAll}}</h4>
 
 <dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>getAll(name, options)</dfn>
@@ -233,7 +239,12 @@ Methods</h3>
 		<pre class=argumentdef for="CookieStore/getAll(options)">
 			options: options
 		</pre>
+</dl>
 
+<h4 id="CookieStore-methods-get">
+{{CookieStore/get}}</h4>
+
+<dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>get(name, options)</dfn>
 	::
 		Get something
@@ -249,6 +260,13 @@ Methods</h3>
 		<pre class=argumentdef for="CookieStore/get(options)">
 			options: options
 		</pre>
+</dl>
+
+
+<h4 id="CookieStore-methods-has">
+{{CookieStore/has}}</h4>
+
+<dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>has(name, options)</dfn>
 	::
 		Has something
@@ -264,6 +282,12 @@ Methods</h3>
 		<pre class=argumentdef for="CookieStore/has(options)">
 			options: options
 		</pre>
+</dl>
+
+<h4 id="CookieStore-methods-set">
+{{CookieStore/set(name, value, options)|set}}</h4>
+
+<dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>set(name, value, options)</dfn>
 	::
 		Set cookie
@@ -280,6 +304,13 @@ Methods</h3>
 		<pre class=argumentdef for="CookieStore/set(options)">
 			options: options
 		</pre>
+
+</dl>
+
+<h4 id="CookieStore-methods-delete">
+{{CookieStore/delete(name, options)|delete}}</h4>
+
+<dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>delete(name, options)</dfn>
 	::
 		Delete something

--- a/index.bs
+++ b/index.bs
@@ -373,3 +373,21 @@ Dictionary {{CookieStoreSetOptions}} Members</h5>
 	:: http only
 </dl>
 
+<h2 id="ServiceWorkerGlobalScopeCookieStore">
+The ServiceWorkerGlobalScopeCookieStore Interface</h2>
+
+<pre class="idl">
+partial interface ServiceWorkerGlobalScope {
+    [Replaceable, SameObject] readonly attribute CookieStore cookieStore;
+};
+</pre>
+
+<h2 id="WindowCookieStore">
+The {{WindowCookieStore}} Interface</h2>
+
+<pre class="idl">
+partial interface Window {
+    [Replaceable, SameObject] readonly attribute CookieStore cookieStore;
+};
+</pre>
+

--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ Although it is tempting to [rethink cookies](https://discourse.wicg.io/t/rethink
 
 Today writing a cookie means blocking your event loop while waiting for the browser to synchronously update the cookie jar with a carefully-crafted cookie string in `Set-Cookie` format:
 
+<div class="example">
 ```js
 document.cookie =
   '__Secure-COOKIENAME=cookie-value' +
@@ -61,9 +62,11 @@ if (String(document.cookie).match(successRegExp)) {
   console.error('It did not work, and we do not know why');
 }
 ```
+</div>
 
 What if you could instead write:
 
+<div class="example">
 ```js
 cookieStore.set(
   '__Secure-COOKIENAME',
@@ -81,6 +84,7 @@ cookieStore.set(
 // Meanwhile we can do other things while waiting for
 // the cookie store to process the write...
 ```
+</div>
 
 This also has the advantage of not relying on `document` and not blocking, which together make it usable from [service workers](https://github.com/slightlyoff/ServiceWorker), which otherwise do not have cookie access from script.
 

--- a/index.bs
+++ b/index.bs
@@ -35,7 +35,7 @@ On the modern web a cookie operation in one part of a web application cannot blo
 
 Newer parts of the web built in service workers [need access to cookies too](https://github.com/slightlyoff/ServiceWorker/issues/707) but cannot use the synchronous, blocking `document.cookie` and `<meta http-equiv="set-cookie" ...>` interfaces at all as they both have no `document` and also cannot block the event loop as that would interfere with handling of unrelated events.
 
-<h3 id="intro-proposed-change>
+<h3 id="intro-proposed-change">
 A Taste of the Proposed Change
 </h3>
 

--- a/index.bs
+++ b/index.bs
@@ -92,9 +92,9 @@ Summary
 
 This proposal outlines an asynchronous API using Promises/async functions for the following cookie operations:
 
-	* [write](#writing) (or "set") cookies
-	* [delete](#clearing) (or "expire") cookies
-	* [read](#reading) (or "get") [script-visible](#script-visibility) cookies
+	* [=set a cookie|write=] (or "set") cookies
+	* [=clearing|delete=] (or "expire") cookies
+	* [=read=] (or "get") [script-visible](#script-visibility) cookies
 		* ... including for specified in-scope request paths in
 			[service worker](https://github.com/slightlyoff/ServiceWorker) contexts
 	* [monitor](#monitoring) [script-visible](#script-visibility) cookies for changes
@@ -244,6 +244,77 @@ Methods</h3>
 <h4 id="CookieStore-methods-get">
 {{CookieStore/get}}</h4>
 
+You can <dfn>read</dfn> the first in-scope script-visible value for a given cookie name. In a service worker context this defaults to the path
+of the service worker's registered scope. In a document it defaults to the path of the current document and does not respect
+changes from `replaceState` or `document.domain`.
+
+<div class="example">
+```js
+function getOneSimpleOriginCookie() {
+  return cookieStore.get('__Host-COOKIENAME').then(function(cookie) {
+    console.log(cookie ? ('Current value: ' + cookie.value) : 'Not set');
+  });
+}
+getOneSimpleOriginCookie().then(function() {
+  console.log('getOneSimpleOriginCookie succeeded!');
+}, function(reason) {
+  console.error('getOneSimpleOriginCookie did not succeed: ', reason);
+});
+```
+</div>
+
+You can use exactly the same Promise-based API with the newer `async` ... `await` syntax and arrow functions for more readable code:
+
+<div class="example">
+```js
+let getOneSimpleOriginCookieAsync = async () => {
+  let cookie = await cookieStore.get('__Host-COOKIENAME');
+  console.log(cookie ? ('Current value: ' + cookie.value) : 'Not set');
+};
+getOneSimpleOriginCookieAsync().then(
+  () => console.log('getOneSimpleOriginCookieAsync succeeded!'),
+  reason => console.error('getOneSimpleOriginCookieAsync did not succeed: ', reason));
+```
+</div>
+
+Remaining examples use this syntax along with destructuring for clarity, and omit the calling code.
+
+In a service worker context you can read a cookie from the point of view of a particular in-scope URL, which may be useful when handling regular (same-origin, in-scope) fetch events or foreign fetch events.
+
+<div class="example">
+```js
+let getOneCookieForRequestUrl = async () => {
+  let cookie = await cookieStore.get('__Secure-COOKIENAME', {url: '/cgi-bin/reboot.php'});
+  console.log(cookie ? ('Current value in /cgi-bin is ' + cookie.value) : 'Not set in /cgi-bin');
+};
+```
+</div>
+
+Sometimes you need to see the whole script-visible in-scope subset of the cookie jar, including potential reuse of the same
+cookie name at multiple paths and/or domains (the paths and domains are not exposed to script by this API, though):
+
+<div class="example">
+```js
+let countCookies = async () => {
+  let cookieList = await cookieStore.getAll();
+  console.log('How many cookies? %d', cookieList.length);
+  cookieList.forEach(cookie => console.log('Cookie %s has value %o', cookie.name, cookie.value));
+};
+```
+</div>
+
+Sometimes an expected cookie is known by a prefix rather than by an exact name, for instance when reading all cookies managed by a particular library (e.g. in [this one](https://developers.google.com/+/web/api/javascript#gapiinteractivepost_interactive_posts) the name prefix identifies the library) or when reading all cookie names owned by a particular application on a shared web host (a name prefix is often used to identify the owning application):
+
+<div class="example">
+```js
+let countMatchingSimpleOriginCookies = async () => {
+  let cookieList = await cookieStore.getAll({name: '__Host-COOKIEN', matchType: 'startsWith'});
+  console.log('How many matching cookies? %d', cookieList.length);
+  cookieList.forEach(({name, value}) => console.log('Matching cookie %s has value %o', name, value));
+};
+```
+</div>
+
 <dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>get(name, options)</dfn>
 	::
@@ -287,6 +358,132 @@ Methods</h3>
 <h4 id="CookieStore-methods-set">
 {{CookieStore/set(name, value, options)|set}}</h4>
 
+You can <dfn>set a cookie</dfn> using these methods.  For example:
+
+<div class="example">
+```js
+let setOneSimpleOriginSessionCookie = async () => {
+  await cookieStore.set('__Host-COOKIENAME', 'cookie-value');
+  console.log('Set!');
+};
+```
+</div>
+
+That defaults to path "/" and *implicit* domain, and defaults to a Secure-if-https-origin, non-HttpOnly session cookie which will be visible to scripts. You can override any of these defaults except for HttpOnly (which is not settable from script in modern browsers) if needed:
+
+<div class="example">
+```js
+let setOneDaySecureCookieWithDate = async () => {
+  // one day ahead, ignoring a possible leap-second
+  let inTwentyFourHours = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  await cookieStore.set('__Secure-COOKIENAME', 'cookie-value', {
+      path: '/cgi-bin/',
+      expires: inTwentyFourHours,
+      secure: true,
+      domain: 'example.org'
+    });
+  console.log('Set!');
+};
+```
+</div>
+
+Of course the numeric form (milliseconds since the beginning of 1970 UTC) works too:
+
+
+<div class="example">
+```js
+let setOneDayUnsecuredCookieWithMillisecondsSinceEpoch = async () => {
+  // one day ahead, ignoring a possible leap-second
+  let inTwentyFourHours = Date.now() + 24 * 60 * 60 * 1000;
+  await cookieStore.set('LEGACYCOOKIENAME', 'cookie-value', {
+      path: '/cgi-bin/',
+      expires: inTwentyFourHours,
+      secure: false,
+      domain: 'example.org'
+    });
+  console.log('Set!');
+};
+```
+</div>
+
+Sometimes an expiration date comes from existing script it's not easy or convenient to replace, though:
+
+<div class="example">
+```js
+let setSecureCookieWithHttpLikeExpirationString = async () => {
+  await cookieStore.set('__Secure-COOKIENAME', 'cookie-value', {
+      path: '/cgi-bin/',
+      expires: 'Mon, 07 Jun 2021 07:07:07 GMT',
+      secure: true,
+      domain: 'example.org'
+    });
+  console.log('Set!');
+};
+```
+</div>
+
+In this case the syntax is that of the HTTP cookies spec; any other syntax will result in promise rejection.
+
+You can set multiple cookies too, but - as with HTTP `Set-Cookie` - the multiple write operations have no guarantee of atomicity:
+
+<div class="example">
+```js
+let setThreeSimpleOriginSessionCookiesSequentially = async () => {
+  await cookieStore.set('__Host-🍪', '🔵cookie-value1🔴');
+  await cookieStore.set('__Host-🌟', '🌠cookie-value2🌠');
+  await cookieStore.set('__Host-🌱', '🔶cookie-value3🔷');
+  console.log('All set!');
+  // NOTE: this assumes no concurrent writes from elsewhere; it also
+  // uses three separate cookie jar read operations where a single getAll
+  // would be more efficient, but this way the CookieStore does the filtering
+  // for us.
+  let matchingValues = await Promise.all(['🍪', '🌟', '🌱'].map(
+    async ಠ_ಠ => (await cookieStore.get('__Host-' + ಠ_ಠ)).value));
+  let actual = matchingValues.join(';');
+  let expected = '🔵cookie-value1🔴;🌠cookie-value2🌠;🔶cookie-value3🔷';
+  if (actual !== expected) {
+    throw new Error([
+      'Expected ',
+      JSON.stringify(expected),
+      ' but got ',
+      JSON.stringify(actual)].join(''));
+  }
+  console.log('All verified!');
+};
+```
+</div>
+
+If the relative order is unimportant the operations can be performed without specifying the order:
+
+<div class="example">
+```js
+let setThreeSimpleOriginSessionCookiesNonsequentially = async () => {
+  await Promise.all([
+    cookieStore.set('__Host-unordered🍪', '🔵unordered-cookie-value1🔴'),
+    cookieStore.set('__Host-unordered🌟', '🌠unordered-cookie-value2🌠'),
+    cookieStore.set('__Host-unordered🌱', '🔶unordered-cookie-value3🔷')]);
+  console.log('All set!');
+  // NOTE: this assumes no concurrent writes from elsewhere; it also
+  // uses three separate cookie jar read operations where a single getAll
+  // would be more efficient, but this way the CookieStore does the filtering
+  // for us.
+  let matchingCookies = await Promise.all(['🍪', '🌟', '🌱'].map(
+    ಠ_ಠ => cookieStore.get('__Host-unordered' + ಠ_ಠ)));
+  let actual = matchingCookies.map(({value}) => value).join(';');
+  let expected =
+    '🔵unordered-cookie-value1🔴;🌠unordered-cookie-value2🌠;🔶unordered-cookie-value3🔷';
+  if (actual !== expected) {
+    throw new Error([
+      'Expected ',
+      JSON.stringify(expected),
+      ' but got ',
+      JSON.stringify(actual)].join(''));
+  }
+  console.log('All verified!');
+};
+```
+</div>
+
 <dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>set(name, value, options)</dfn>
 	::
@@ -309,6 +506,49 @@ Methods</h3>
 
 <h4 id="CookieStore-methods-delete">
 {{CookieStore/delete(name, options)|delete}}</h4>
+
+<dfn>Clearing</dfn> (deleting) a cookie is accomplished by expiration, that is by replacing it with an equivalent-scope cookie with
+an expiration in the past:
+
+```js
+let setExpiredSecureCookieWithDomainPathAndFallbackValue = async () => {
+  let theVeryRecentPast = Date.now();
+  let expiredCookieSentinelValue = 'EXPIRED';
+  await cookieStore.set('__Secure-COOKIENAME', expiredCookieSentinelValue, {
+      path: '/cgi-bin/',
+      expires: theVeryRecentPast,
+      secure: true,
+      domain: 'example.org'
+    });
+  console.log('Expired! Deleted!! Cleared!!1!');
+};
+```
+
+In this case the cookie's value is not important unless a clock is somehow re-set incorrectly or otherwise behaves nonmonotonically or incoherently.
+
+A syntactic shorthand is also provided which is equivalent to the above except that the clock's accuracy and monotonicity becomes irrelevant:
+
+```js
+let deleteSimpleOriginCookie = async () => {
+  await cookieStore.delete('__Host-COOKIENAME');
+  console.log('Expired! Deleted!! Cleared!!1!');
+};
+```
+
+Again, the path and/or domain can be specified explicitly here.
+
+```js
+let deleteSecureCookieWithDomainAndPath = async () => {
+  await cookieStore.delete('__Secure-COOKIENAME', {
+      path: '/cgi-bin/',
+      domain: 'example.org',
+      secure: true
+    });
+  console.log('Expired! Deleted!! Cleared!!1!');
+};
+```
+
+This API has semantics aligned with the interpretation of `Max-Age=0` common to most modern browsers.
 
 <dl dfn-type=method dfn-for="CookieStore">
 	: <dfn>delete(name, options)</dfn>


### PR DESCRIPTION
Bikeshed the spec.

Copied large parts of the explainer to the spec.  Don't really know what I'm doing, but it reads ok.

Build using
```
bikeshed -f spec
```

There are currently two errors and lots of notes:

> FATAL ERROR: IDL ERROR LINE: 20 - Dictionary argument "options" without required members must be marked optional
FATAL ERROR: IDL ERROR LINE: 25 - Dictionary argument "options" without required members must be marked optional
LINE 235: Can't find the 'name' argument of method 'CookieStore/getAll(options)' in the argumentdef block.
LINE 327: Can't find the 'name' argument of method 'CookieStore/get(options)' in the argumentdef block.
LINE 349: Can't find the 'name' argument of method 'CookieStore/has(options)' in the argumentdef block.
LINE 496: Can't find the 'name' argument of method 'CookieStore/set(options)' in the argumentdef block.
LINE 496: Can't find the 'value' argument of method 'CookieStore/set(options)' in the argumentdef block.
LINE 562: Can't find the 'name' argument of method 'CookieStore/delete(options)' in the argumentdef block.
LINE ~104: Couldn't find target anchor monitoring:
[monitor](#monitoring)
YAY Successfully generated, but fatal errors were suppressed


I didn't know where to put the monitoring text from the explainer to the spec, so that link is broken.

The two errors are reported in WICG/cookie-store#49.  I'm going to  wait for someone to fix it the right way.
