### PR TITLE
IDL fixes for the specification.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -216,8 +216,8 @@ interface CookieStore : EventTarget {
   Promise<CookieListItem?> get(USVString name);
   Promise<CookieListItem?> get(optional CookieStoreGetOptions options);
 
-  Promise<CookieList?> getAll(USVString name);
-  Promise<CookieList?> getAll(optional CookieStoreGetOptions options);
+  Promise<CookieList> getAll(USVString name);
+  Promise<CookieList> getAll(optional CookieStoreGetOptions options);
 
   Promise<void> set(USVString name, USVString value,
                     optional CookieStoreSetOptions options);
@@ -271,17 +271,17 @@ dictionary CookieStoreDeleteOptions {
   USVString? domain = null;
   USVString path = "/";
   boolean secure = true;
-  boolean httpOnly = false;
   CookieSameSite sameSite = "strict";
 };
 
 dictionary CookieListItem {
-  USVString name;
+  required USVString name;
   USVString value;
-  USVString? domain;
-  USVString path;
-  DOMTimeStamp? expires;
-  boolean secure;
+  USVString? domain = null;
+  USVString path = "/";
+  DOMTimeStamp? expires = null;
+  boolean secure = true;
+  CookieSameSite sameSite = "strict";
 };
 
 typedef sequence<CookieListItem> CookieList;


### PR DESCRIPTION
* cookieStore.getAll() is guaranteed to return a CookieList
* CookieListItem's defaults are specified, because they're observable
  when initializing cookie change events (to be spec'd)
* httpOnly doesn't make sense on CookieStoreDeleteOptions