### PR TITLE
Fix #85: compile.sh exits if anything fails

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -3,9 +3,15 @@
 # So we can see what we're doing
 set -x
 
-# Run bikeshed.
+# Exist with nonzero exit code if anything fails
+set -e
+
+# Run bikeshed.  If there are errors, exit with a non-zero code
 bikeshed --print=plain -f spec
 
 # The out directory should contain everything needed to produce the
-# HTML version of the spec.
-cp index.html out
+# HTML version of the spec.  Copy things there if the directory exists.
+
+if [ -d out ]; then
+    cp index.html out
+fi

--- a/compile.sh
+++ b/compile.sh
@@ -3,7 +3,7 @@
 # So we can see what we're doing
 set -x
 
-# Exist with nonzero exit code if anything fails
+# Exit with nonzero exit code if anything fails
 set -e
 
 # Run bikeshed.  If there are errors, exit with a non-zero code


### PR DESCRIPTION
Also, if the out directory doesn't exist, don't copy anything there.
Mostly useful when running local so we don't try to copy things to the
non-existent directory.