### PR TITLE
Handle unspecified name in query cookies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1040,9 +1040,10 @@ run the following steps:
 1. Let |list| be a new [=list=].
 1. [=list/For each=] |cookie| in |cookie-list|, run these steps:
     1. Assert: |cookie|'s [=cookie/http-only-flag=] is false.
-    1. Let |cookieName| be |cookie|'s [=cookie/name=] ([=decoded=]).
-    1. If |cookieName| does not [=match=] |name| using |matchType|,
-        then [=continue=].
+    1. If |name| is given, then run these steps:
+        1. Let |cookieName| be |cookie|'s [=cookie/name=] ([=decoded=]).
+        1. If |cookieName| does not [=match=] |name| using |matchType|,
+             then [=continue=].
     1. Let |item| be the result of running the steps to [=create a CookieListItem=] from |cookie|.
     1. [=list/Append=] |item| to |list|.
 1. Return |list|.


### PR DESCRIPTION
Per note in #94 it seems like this case was missing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/95.html" title="Last updated on Oct 26, 2018, 7:50 PM GMT (5e87ba7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/95/763ab6a...5e87ba7.html" title="Last updated on Oct 26, 2018, 7:50 PM GMT (5e87ba7)">Diff</a>