### PR TITLE
Editorial: Fix API typo in URL

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -259,7 +259,7 @@ await cookieStore.set({
   expires: null,  // session cookie
 
   // By default, cookies are scoped at the current domain.
-  domain: (new URL(self.location.href)).domain,
+  domain: (new URL(self.location.href)).hostname,
   path: '/',
 
   // Creates secure cookies by default on secure origins.

--- a/index.bs
+++ b/index.bs
@@ -342,7 +342,7 @@ await cookieStore.set({
   expires: null,  // session cookie
 
   // By default, cookies are scoped at the current domain.
-  domain: (new URL(self.location.href)).domain,
+  domain: (new URL(self.location.href)).hostname,
   path: '/',
 
   // Creates secure cookies by default on secure origins.


### PR DESCRIPTION
Fixes #98 

`(new URL(self.location.href)).domain` => `(new URL(self.location.href)).hostname`

As per the issue above.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/remy/cookie-store/pull/99.html" title="Last updated on Feb 5, 2019, 5:59 PM UTC (549c9fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/99/96a877a...remy:549c9fc.html" title="Last updated on Feb 5, 2019, 5:59 PM UTC (549c9fc)">Diff</a>