### PR TITLE
Bump version of RFC6265bis being referenced from 02 to 03

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Cookie Store API has also been discussed in the following places.
 
 The best resource for understanding the deep technical aspects of cookies is
 the most recent draft of
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02).
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03).
 
 This API aims to replace
 [document.cookie](https://www.w3.org/TR/html/dom.html#dom-document-cookie)

--- a/explainer.md
+++ b/explainer.md
@@ -551,7 +551,7 @@ foresight to handle errors they might not experience while building their sites.
 
 ## Related Work
 
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02)
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03)
 explains HTTP cookies. Cookies were implemented independently in separate HTTP
 stacks without a comprehensive testing suite, leading to visible cross-browser
 incompatibilities. The RFC explains many of these incompatibilities and lays out

--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ Test Suite: https://github.com/web-platform-tests/wpt/tree/master/cookie-store
 {
   "RFC6265bis": {
     "authors": [ "A. Barth", "M. West" ],
-    "href": "https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02",
+    "href": "https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03",
     "title": "Cookies: HTTP State Management Mechanism",
     "publisher": "IETF",
     "status": "Internet-Draft"

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -26,7 +26,7 @@ This specification defers to
 the storage and security models of HTTP cookies. Cookies can be scoped to an
 entire eTLD+1, transcending the same origin policy. For example, a cookie
 whose
-[domain](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-5.3.3)
+[domain](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.3)
 attribute is set to `example.com` is visible to `www.example.com` and
 `foo.example.com`.
 
@@ -73,7 +73,7 @@ No.
 This specification defers to
 [RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03) for
 the storage and security models of HTTP cookies. Cookies have a
-[SameSite](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-5.3.7)
+[SameSite](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7)
 attribute that introduces differences in behavior between first-party and
 third-party contexts.
 

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -22,11 +22,11 @@ mechanism is introduced.
 Yes. However, it does not expose any **new** persistent cross-origin state.
 
 This specification defers to
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02) for
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03) for
 the storage and security models of HTTP cookies. Cookies can be scoped to an
-entire eTLD+1, transcending the same origin policy. For eaxmple, a cookie
+entire eTLD+1, transcending the same origin policy. For example, a cookie
 whose
-[domain](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-4.1.2.3)
+[domain](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-5.3.3)
 attribute is set to `example.com` is visible to `www.example.com` and
 `foo.example.com`.
 
@@ -71,9 +71,9 @@ No.
 No.
 
 This specification defers to
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02) for
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03) for
 the storage and security models of HTTP cookies. Cookies have a
-[SameSite](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-4.1.2.7)
+[SameSite](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-5.3.7)
 attribute that introduces differences in behavior between first-party and
 third-party contexts.
 
@@ -83,7 +83,7 @@ attribute.
 ### 3.14 How should this specification work in the context of a user agent’s "incognito" mode?
 
 This specification builds on top of HTTP cookies as defined in
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02). The
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03). The
 specification should be compatible with any manner user agents choose to handle
  cookies in "incognito".
 
@@ -96,11 +96,11 @@ Yes. However, it does not introduce any **new** persistence mechanism.
 No.
 
 The specification will defer to
-[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02) for
+[RFC 6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03) for
 its extensive treatment of
-[Security](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-8)
+[Security](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-8)
 and
-[Privacy](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-7)
+[Privacy](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-7)
 issues.
 
 ### 3.17 Does this specification allow downgrading default security characteristics?


### PR DESCRIPTION
Section numbers / titles appear to be unchanged.

Note that https://github.com/WICG/cookie-store/issues/102 still needs to be processed to align the SameSite changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/103.html" title="Last updated on May 8, 2019, 5:36 PM UTC (8bebf03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/103/5a4c542...8bebf03.html" title="Last updated on May 8, 2019, 5:36 PM UTC (8bebf03)">Diff</a>