### PR TITLE
Make Raymond Toy a former editor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,9 +7,9 @@ Group: WICG
 ED: https://wicg.github.io/cookie-store/
 Repository: WICG/cookie-store
 Editor: Victor Costan, Google Inc. https://google.com, costan@google.com
-Editor: Raymond Toy, Google Inc. https://google.com, rtoy@google.com
 Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com
 Favicon: logo-cookies.png
+Former Editor: Raymond Toy, Google Inc. https://google.com, rtoy@google.com
 Markup Shorthands: markdown yes, css no, biblio yes
 Abstract: An asynchronous Javascript cookies API for documents and workers
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/cookie-store


### PR DESCRIPTION
Done based on note from Chris Wilson about WICG and WebApps WG.
Moving myself to former editor.  I'm not really involved with this
anymore either.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/106.html" title="Last updated on Jul 12, 2019, 9:05 PM UTC (ecfe1aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/106/72fd989...ecfe1aa.html" title="Last updated on Jul 12, 2019, 9:05 PM UTC (ecfe1aa)">Diff</a>