### PR TITLE
Add dictionary default value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -525,13 +525,13 @@ a [=tuple=] of <dfn>name</dfn>, <dfn>url</dfn>, and <dfn>matchType</dfn>.
  SecureContext]
 interface CookieStore : EventTarget {
   Promise<CookieListItem?> get(USVString name);
-  Promise<CookieListItem?> get(optional CookieStoreGetOptions options);
+  Promise<CookieListItem?> get(optional CookieStoreGetOptions options = {});
 
   Promise<CookieList> getAll(USVString name);
-  Promise<CookieList> getAll(optional CookieStoreGetOptions options);
+  Promise<CookieList> getAll(optional CookieStoreGetOptions options = {});
 
   Promise<void> set(USVString name, USVString value,
-                    optional CookieStoreSetOptions options);
+                    optional CookieStoreSetOptions options = {});
   Promise<void> set(CookieStoreSetExtraOptions options);
 
   Promise<void> delete(USVString name);


### PR DESCRIPTION
Required after heycam/webidl#750. (Found from web-platform-tests/wpt#18382)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/cookie-store/pull/108.html" title="Last updated on Aug 20, 2019, 2:16 PM UTC (9dd257d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/108/fc49b7b...saschanaz:9dd257d.html" title="Last updated on Aug 20, 2019, 2:16 PM UTC (9dd257d)">Diff</a>