### PR TITLE
Linkify various Infra/IDL/HTML terms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,6 +37,7 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
 <pre class=link-defaults>
 spec:infra; type:dfn; text:list
 spec:html; type:dfn; for:environment settings object; text:global object
+spec:webidl; type:dfn; text:resolve
 </pre>
 
 <style>
@@ -616,16 +617,16 @@ typedef sequence<CookieListItem> CookieList;
 <div class=algorithm>
 The <dfn method for=CookieStore>get(|name|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |list| be the results of running the steps to [=query cookies=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |list| be the results of running [=query cookies=] with
         |url| and |name|.
-    1. If |list| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. If |list| [=list/is empty=], then resolve |p| with undefined.
-    1. Otherwise, resolve |p| with the first item of |list|.
+    1. If |list| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. If |list| [=list/is empty=], then [=resolve=] |p| with undefined.
+    1. Otherwise, [=resolve=] |p| with the first item of |list|.
 1. Return |p|.
 
 </div>
@@ -633,25 +634,25 @@ The <dfn method for=CookieStore>get(|name|)</dfn> method, when invoked, must run
 <div class=algorithm>
 The <dfn method for=CookieStore>get(|options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
 1. If |options|' {{CookieStoreGetOptions/url}} dictionary member is present, then run these steps:
     1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with the [=context object=]'s [=relevant settings object=]'s [=API base URL=].
     1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
-        then return a new promise rejected with a {{TypeError}}.
+        then return [=a promise rejected with=] a {{TypeError}}.
     1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
-        then return a new promise rejected with a {{TypeError}}.
+        then return [=a promise rejected with=] a {{TypeError}}.
     1. Set |url| to |parsed|.
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |list| be the results of running the steps to [=query cookies=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |list| be the results of running [=query cookies=] with
         |url|,
         |options|' {{CookieStoreGetOptions/name}} dictionary member (if present), and
         |options|' {{CookieStoreGetOptions/matchType}} dictionary member.
-    1. If |list| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. If |list| [=list/is empty=], then resolve |p| with undefined.
-    1. Otherwise, resolve |p| with the first item of |list|.
+    1. If |list| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. If |list| [=list/is empty=], then [=resolve=] |p| with undefined.
+    1. Otherwise, [=resolve=] |p| with the first item of |list|.
 1. Return |p|.
 
 </div>
@@ -678,15 +679,15 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method, when invoked, must 
 <div class=algorithm>
 The <dfn method for=CookieStore>getAll(|name|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |list| be the results of running the steps to [=query cookies=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |list| be the results of running [=query cookies=] with
         |url| and |name|.
-    1. If |list| is failure, then reject |p| with a {{TypeError}}.
-    1. Otherwise, resolve |p| with |list|.
+    1. If |list| is failure, then [=reject=] |p| with a {{TypeError}}.
+    1. Otherwise, [=resolve=] |p| with |list|.
 1. Return |p|.
 
 </div>
@@ -694,24 +695,24 @@ The <dfn method for=CookieStore>getAll(|name|)</dfn> method, when invoked, must 
 <div class=algorithm>
 The <dfn method for=CookieStore>getAll(|options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
 1. If |options|' {{CookieStoreGetOptions/url}} dictionary member is present, then run these steps:
     1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with the [=context object=]'s [=relevant settings object=]'s [=API base URL=].
     1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
-        then return a new promise rejected with a {{TypeError}}.
+        then return [=a promise rejected with=] a {{TypeError}}.
     1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
-        then return a new promise rejected with a {{TypeError}}.
+        then return [=a promise rejected with=] a {{TypeError}}.
     1. Set |url| to |parsed|.
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |list| be the results of running the steps to [=query cookies=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |list| be the results of running [=query cookies=] with
         |url|,
         |options|' {{CookieStoreGetOptions/name}} dictionary member (if present), and
         |options|' {{CookieStoreGetOptions/matchType}} dictionary member.
-    1. If |list| is failure, then reject |p| with a {{TypeError}}.
-    1. Otherwise, resolve |p| with |list|.
+    1. If |list| is failure, then [=reject=] |p| with a {{TypeError}}.
+    1. Otherwise, [=resolve=] |p| with |list|.
 1. Return |p|.
 
 </div>
@@ -743,12 +744,12 @@ The <dfn method for=CookieStore>getAll(|options|)</dfn> method, when invoked, mu
 <div class=algorithm>
 The <dfn method for=CookieStore>set(|name|, |value|, |options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |r| be the result of running the steps to [=set a cookie=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |r| be the result of running [=set a cookie=] with
         |url|,
         |name|,
         |value|,
@@ -757,8 +758,8 @@ The <dfn method for=CookieStore>set(|name|, |value|, |options|)</dfn> method, wh
         |options|' {{CookieStoreSetOptions/path}} dictionary member,
         |options|' {{CookieStoreSetOptions/secure}} dictionary member, and
         |options|' {{CookieStoreSetOptions/sameSite}} dictionary member.
-    1. If |r| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. Resolve |p| with undefined.
+    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. [=Resolve=] |p| with undefined.
 1. Return |p|.
 
 </div>
@@ -766,12 +767,12 @@ The <dfn method for=CookieStore>set(|name|, |value|, |options|)</dfn> method, wh
 <div class=algorithm>
 The <dfn method for=CookieStore>set(|options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |r| be the result of running the steps to [=set a cookie=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |r| be the result of running [=set a cookie=] with
         |url|,
         |options|' {{CookieStoreSetExtraOptions/name}} dictionary member,
         |options|' {{CookieStoreSetExtraOptions/value}} dictionary member,
@@ -780,8 +781,8 @@ The <dfn method for=CookieStore>set(|options|)</dfn> method, when invoked, must 
         |options|' {{CookieStoreSetOptions/path}} dictionary member,
         |options|' {{CookieStoreSetOptions/secure}} dictionary member, and
         |options|' {{CookieStoreSetOptions/sameSite}} dictionary member.
-    1. If |r| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. Resolve |p| with undefined.
+    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. [=Resolve=] |p| with undefined.
 1. Return |p|.
 
 </div>
@@ -806,20 +807,20 @@ The <dfn method for=CookieStore>set(|options|)</dfn> method, when invoked, must 
 <div class=algorithm>
 The <dfn method for=CookieStore>delete(|name|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |r| be the result of running the steps to [=delete a cookie=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |r| be the result of running [=delete a cookie=] with
         |url|,
         |name|,
         null,
         "`/`",
         true, and
         "{{CookieSameSite/strict}}".
-    1. If |r| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. Resolve |p| with undefined.
+    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. [=Resolve=] |p| with undefined.
 1. Return |p|.
 
 </div>
@@ -827,18 +828,18 @@ The <dfn method for=CookieStore>delete(|name|)</dfn> method, when invoked, must 
 <div class=algorithm>
 The <dfn method for=CookieStore>delete(|options|)</dfn> method, when invoked, must run these steps:
 
-1. Let |origin| be |environment|’s [=/origin=].
-1. If |origin| is an [=opaque origin=], then return a new promise rejected with a "{{SecurityError}}" {{DOMException}}.
+1. Let |origin| be the [=current settings object=]'s [=/origin=].
+1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
-    1. Let |r| be the result of running the steps to [=delete a cookie=] with
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
+    1. Let |r| be the result of running [=delete a cookie=] with
         |url|,
         |options|' {{CookieStoreDeleteOptions/name}} dictionary member,
         |options|' {{CookieStoreDeleteOptions/domain}} dictionary member, and
         |options|' {{CookieStoreDeleteOptions/path}} dictionary member.
-    1. If |r| is failure, then reject |p| with a {{TypeError}} and abort these steps.
-    1. Resolve |p| with undefined.
+    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. [=Resolve=] |p| with undefined.
 1. Return |p|.
 
 </div>
@@ -868,19 +869,19 @@ The <dfn method for=CookieStore>subscribeToChanges(|subscriptions|)</dfn> method
 
 1. Let |serviceWorker| be the [=context object=]'s [=global object=]'s [=service worker=].
 1. If |serviceWorker|'s [=service worker/state=] is not *installing*,
-    then return a new promise rejected with a {{TypeError}}.
+    then return [=a promise rejected with=] a {{TypeError}}.
 1. Let |registration| be |serviceWorker|'s associated [=containing service worker registration=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
     1. [=list/For each=] |entry| in |subscriptions|, run these steps:
         1. Let |name| be |entry|'s {{CookieStoreGetOptions/name}} member.
         1. Let |url| be the result of [=basic URL parser|parsing=] |entry|'s {{CookieStoreGetOptions/url}} dictionary member with the [=context object=]'s [=relevant settings object=]'s [=API base URL=].
         1. If |url| does not start with |registration|'s [=service worker registration/scope url=],
-            then reject |p| with a {{TypeError}} and abort these steps.
+            then [=reject=] |p| with a {{TypeError}} and abort these steps.
         1. Let |matchType| be |entry|'s {{CookieStoreGetOptions/matchType}} member.
         1. Let |subscription| be the [=cookie change subscription=] (|name|, |url|, |matchType|).
         1. Append |subscription| to |registration|'s associated [=cookie change subscription list=].
-    1. Resolve |p| with undefined.
+    1. [=Resolve=] |p| with undefined.
 1. Return |p|.
 
 </div>
@@ -905,8 +906,8 @@ The <dfn method for=CookieStore>getChangeSubscriptions()</dfn> method, when invo
 
 1. Let |serviceWorker| be the [=context object=]'s [=global object=]'s [=service worker=].
 1. Let |registration| be |serviceWorker|'s associated [=containing service worker registration=].
-1. Let |p| be a new promise.
-1. Run the following steps in parallel:
+1. Let |p| be [=a new promise=].
+1. Run the following steps [=in parallel=]:
     1. Let |subscriptions| be |registration|'s associated [=cookie change subscription list=].
     1. Let |result| be a new [=list=].
     1. [=list/For each=] |subscription| in |subscriptions|, run these steps:
@@ -914,7 +915,7 @@ The <dfn method for=CookieStore>getChangeSubscriptions()</dfn> method, when invo
         1. Set |options|'s {{CookieStoreGetOptions/name}} member to |subscription|'s [=cookie change subscription/name=].
         1. Set |options|'s {{CookieStoreGetOptions/url}} member to |subscription|'s [=cookie change subscription/url=].
         1. Set |options|'s {{CookieStoreGetOptions/matchType}} member to |subscription|'s [=cookie change subscription/matchType=].
-    1. Resolve |p| with |result|.
+    1. [=Resolve=] |p| with |result|.
 1. Return |p|.
 
 </div>
@@ -992,7 +993,7 @@ partial interface Window {
 };
 </xmp>
 
-The {{Window/cookieStore}} attribute’s getter must return [=context object=]’s [=relevant settings object=]’s {{CookieStore}} object.
+The {{Window/cookieStore}} attribute's getter must return [=context object=]'s [=relevant settings object=]'s {{CookieStore}} object.
 
 <!-- ============================================================ -->
 ## The {{ServiceWorkerGlobalScope}} interface ## {#ServiceWorkerGlobalScope}
@@ -1006,7 +1007,7 @@ partial interface ServiceWorkerGlobalScope {
 };
 </xmp>
 
-The {{ServiceWorkerGlobalScope/cookieStore}} attribute’s getter must return [=context object=]’s [=relevant settings object=]’s {{CookieStore}} object.
+The {{ServiceWorkerGlobalScope/cookieStore}} attribute's getter must return [=context object=]'s [=relevant settings object=]'s {{CookieStore}} object.
 
 <!-- ============================================================ -->
 # Algorithms # {#algorithms}
@@ -1044,7 +1045,7 @@ run the following steps:
         1. Let |cookieName| be |cookie|'s [=cookie/name=] ([=decoded=]).
         1. If |cookieName| does not [=match=] |name| using |matchType|,
              then [=continue=].
-    1. Let |item| be the result of running the steps to [=create a CookieListItem=] from |cookie|.
+    1. Let |item| be the result of running [=create a CookieListItem=] from |cookie|.
     1. [=list/Append=] |item| to |list|.
 1. Return |list|.
 
@@ -1130,7 +1131,7 @@ optional |expires|,
 |sameSite|,
 run the following steps:
 
-1. If |name| is empty and |value| contains U+003D (`=`), then return failure.
+1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
 1. Let |host| be |url|'s [=url/host=]
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002D (`.`), then return failure.
@@ -1200,7 +1201,7 @@ run the following steps:
     Note: The values for |value|, |secure|, and |sameSite| will not be persisted
     by this algorithm.
 
-1. Return the results of running the steps to [=set a cookie=] with
+1. Return the results of running [=set a cookie=] with
     |url|,
     |name|,
     |value|,
@@ -1239,7 +1240,7 @@ To <dfn>process cookie changes</dfn>, run the following steps:
             1. If |cookie|'s [=cookie/name=] ([=decoded=]) [=matches=] |subscription|'s [=cookie change subscription/name=] using |subscription|'s [=cookie change subscription/matchType=],
                 then [=set/append=] |change| to |changes| and [=break=].
     1. If |changes| [=set/is empty=], then [=continue=].
-    1. Let |changedList| and |deletedList| be the result of running the steps to [=prepare lists=] using |changes| for |registration|.
+    1. Let |changedList| and |deletedList| be the result of running [=prepare lists=] using |changes| for |registration|.
     1. [=Fire a functional event=] named "`cookiechange`"
         using {{ExtendableCookieChangeEvent}} on |registration|
         with these properties:
@@ -1272,7 +1273,7 @@ To <dfn>fire a change event</dfn> named |type| with |changes| at |target|, run t
 1. Let |event| be the result of [=creating an Event=] using {{CookieChangeEvent}}.
 1. Set |event|'s {{Event/type}} attribute to |type|.
 1. Set |event|'s {{Event/bubbles}} and {{Event/cancelable}} attributes to false.
-1. Let |changedList| and |deletedList| be the result of running the steps to [=prepare lists=] using |changes| for |target|.
+1. Let |changedList| and |deletedList| be the result of running [=prepare lists=] using |changes| for |target|.
 1. Set |event|'s {{CookieChangeEvent/changed}} attribute to |changedList|.
 1. Set |event|'s {{CookieChangeEvent/deleted}} attribute to |deletedList|.
 1. [=Dispatch=] |event| at |target|.
@@ -1286,7 +1287,7 @@ To <dfn>prepare lists</dfn> using |changes| for |target|, run the following step
 1. Let |changedList| be a new [=list=].
 1. Let |deletedList| be a new [=list=].
 1. [=set/For each=] |change| in |changes|, run these steps:
-    1. Let |item| be the result of running the steps to [=create a CookieListItem=] from |change|'s cookie.
+    1. Let |item| be the result of running [=create a CookieListItem=] from |change|'s cookie.
     1. If |change|'s type is *changed*, then [=list/append=] |item| to |changedList|.
     1. Otherwise, run these steps:
         1. Set |item|'s {{CookieListItem/value}} dictionary member to undefined.


### PR DESCRIPTION
* WebIDL links for promise creation, resolution, rejection.
* Infra links for 'in parallel', string length.
* Use 'current environment object' to get origin on calls.
* Drop 'the steps to' when invoking an algorithm


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/112.html" title="Last updated on Oct 7, 2019, 7:59 PM UTC (2c6ef49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/112/0dcff99...2c6ef49.html" title="Last updated on Oct 7, 2019, 7:59 PM UTC (2c6ef49)">Diff</a>