### PR TITLE
Rename 'unrestricted' to 'none' to align with RFC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -561,7 +561,7 @@ dictionary CookieStoreGetOptions {
 enum CookieSameSite {
   "strict",
   "lax",
-  "unrestricted"
+  "none"
 };
 
 dictionary CookieStoreSetOptions {
@@ -1086,7 +1086,7 @@ To <dfn>create a {{CookieListItem}}</dfn> from |cookie|, run the following steps
 1. Switch on |cookie|'s [=cookie/same-site-flag=]:
     <dl class=switch>
         : \``None`\`
-        :: Set |item|'s {{CookieListItem/sameSite}} dictionary member to "{{CookieSameSite/unrestricted}}".
+        :: Set |item|'s {{CookieListItem/sameSite}} dictionary member to "{{CookieSameSite/none}}".
         : \``Strict`\`
         :: Set |item|'s {{CookieListItem/sameSite}} dictionary member to "{{CookieSameSite/strict}}".
         : \``Lax`\`
@@ -1147,8 +1147,8 @@ run the following steps:
 1. If |secure| is true, then [=list/append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>
-        : "{{CookieSameSite/unrestricted}}"
-        :: Do nothing.
+        : "{{CookieSameSite/none}}"
+        :: [=list/Append=] \``SameSite`\`/\``None`\` to |attributes|.
         : "{{CookieSameSite/strict}}"
         :: [=list/Append=] \``SameSite`\`/\``Strict`\` to |attributes|.
         : "{{CookieSameSite/lax}}"


### PR DESCRIPTION
Per #102 - now that RFC6265bis adds "none", use that rather than "unrestricted"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/115.html" title="Last updated on Oct 8, 2019, 8:49 PM UTC (ef97979)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/115/0dcff99...ef97979.html" title="Last updated on Oct 8, 2019, 8:49 PM UTC (ef97979)">Diff</a>