### PR TITLE
Explainer fixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -423,19 +423,21 @@ In [=service workers=], `cookiechange` events are fired against the global scope
 Register for `cookiechange` events in a service worker:
 
 ```js
-self.addEventListener('activate', async (event) => {
-  // Snapshot current state of subscriptions.
-  const subscriptions = await self.registration.cookies.getSubscriptions();
+self.addEventListener('activate', (event) => {
+  event.waitUntil(async () => {
+    // Snapshot current state of subscriptions.
+    const subscriptions = await self.registration.cookies.getSubscriptions();
 
-  // Clear any existing subscriptions.
-  await self.registration.cookies.unsubscribe(subscriptions);
+    // Clear any existing subscriptions.
+    await self.registration.cookies.unsubscribe(subscriptions);
 
-  await self.registration.cookies.subscribe([
-    {
-      name: 'session',  // Get change events for session-related cookies.
-      matchType: 'starts-with',  // Matches session_id, session-id, etc.
-    }
-  ]);
+    await self.registration.cookies.subscribe([
+      {
+        name: 'session',  // Get change events for session-related cookies.
+        matchType: 'starts-with',  // Matches session_id, session-id, etc.
+      }
+    ]);
+  });
 });
 
 self.addEventListener('cookiechange', event => {


### PR DESCRIPTION
1) Fixes call to CookieStoreManager.unsubscribe(), which now receives
   a list of subscriptions.
2) Fixes all instances of await being used in non-async functions.
3) Fixes unfinished sentences noticed along the way.

Fixes #118, Fixes #119, Fixes #120


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/123.html" title="Last updated on Feb 5, 2020, 7:25 PM UTC (cd6de5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/123/f9c7e21...cd6de5f.html" title="Last updated on Feb 5, 2020, 7:25 PM UTC (cd6de5f)">Diff</a>