### PR TITLE
Fix SW bug and dfn links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,7 @@ spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
 spec:infra; type:dfn; text:list
 spec:html; type:dfn; for:environment settings object; text:global object
 spec:webidl; type:dfn; text:resolve
+spec:service-workers; type:dfn; for:/; text:service worker
 </pre>
 
 <style>
@@ -84,7 +85,7 @@ On the modern web a cookie operation in one part of a web application cannot blo
   - the rest of the web origin, or
   - the browser as a whole.
 
-Newer parts of the web built in service workers [need access to cookies too](https://github.com/slightlyoff/ServiceWorker/issues/707) but cannot use the synchronous, blocking {{Document/cookie|document.cookie}} interface at all as they both have no `document` and also cannot block the event loop as that would interfere with handling of unrelated events.
+Newer parts of the web built in service workers [need access to cookies too](https://github.com/w3c/ServiceWorker/issues/707) but cannot use the synchronous, blocking {{Document/cookie|document.cookie}} interface at all as they both have no `document` and also cannot block the event loop as that would interfere with handling of unrelated events.
 
 <!-- ============================================================ -->
 ## A Taste of the Proposed Change ## {#intro-proposed-change}
@@ -173,7 +174,7 @@ A cookie is <dfn>script-visible</dfn> when it is in-scope and does not have the 
 
 Issue: Review/rewrite this section.
 
-Some service workers [need access to cookies](https://github.com/slightlyoff/ServiceWorker/issues/707) but
+Some service workers [need access to cookies](https://github.com/w3c/ServiceWorker/issues/707) but
 cannot use the synchronous, blocking {{Document/cookie|document.cookie}} interface as they both have no `document` and
 also cannot block the event loop as that would interfere with handling of unrelated events.
 


### PR DESCRIPTION
Two editorial fixes for minor issues:

* Bikeshed identified "Multiple possible 'service worker' dfn refs."; added a link default.
* Some bug links were to the previous SW repo location; updated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/129.html" title="Last updated on Mar 20, 2020, 6:47 PM UTC (562da76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/129/fe40c65...562da76.html" title="Last updated on Mar 20, 2020, 6:47 PM UTC (562da76)">Diff</a>