### PR TITLE
Fix description for querying in non-secure context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1402,7 +1402,7 @@ For these reasons it is best to use caution when interpreting any cookie's value
 ## Restrict? ## {#restrict}
 <!-- ============================================================ -->
 
-This API may have the unintended side-effect of making cookies easier to use and consequently encouraging their further use. If it causes their further use in unsecured `http` contexts this could result in a web less safe for users. For that reason it may be desirable to restrict its use, or at least the use of the `set` and `delete` operations, to secure origins running in secure contexts.
+This API may have the unintended side-effect of making cookies easier to use and consequently encouraging their further use. If it causes their further use in unsecured `http` contexts this could result in a web less safe for users. For that reason this API has been restricted to secure contexts only.
 
 <!-- ============================================================ -->
 ## Surprises ## {#surprises}


### PR DESCRIPTION
This change updates Restrict section to reflect decision for not allowing querying for non-secure context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/133.html" title="Last updated on Apr 6, 2020, 10:01 PM UTC (2c7f965)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/133/57383b7...2c7f965.html" title="Last updated on Apr 6, 2020, 10:01 PM UTC (2c7f965)">Diff</a>