### PR TITLE
Updating domain default definition

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -263,8 +263,8 @@ await cookieStore.set({
   value: '1',
   expires: null,  // session cookie
 
-  // By default, cookies are scoped at the current domain.
-  domain: (new URL(self.location.href)).hostname,
+  // By default, domain is set to null which means the scope is locked at the current domain.
+  domain: null,
   path: '/',
 
   // Creates secure cookies by default on secure origins.

--- a/index.bs
+++ b/index.bs
@@ -355,8 +355,8 @@ await cookieStore.set({
   value: '1',
   expires: null,  // session cookie
 
-  // By default, cookies are scoped at the current domain.
-  domain: (new URL(self.location.href)).hostname,
+  // By default, domain is set to null which means the scope is locked at the current domain.
+  domain: null,
   path: '/',
 
   // Creates secure cookies by default on secure origins.
@@ -1222,7 +1222,10 @@ run the following steps:
     1. If |host| does not equal |domain| and
         |host| does not end with U+002D (`.`) followed by |domain|,
         then return failure.
-1. Otherwise, if |domain| is null, then set |domain| to |host|.
+    1. Otherwise, set the cookie's |host-only-flag| to false.
+1. Otherwise, if |domain| is null, run these steps:
+    1. Set the cookie's |host-only-flag| to true.
+    1. Set |domain| to |host|.
 1. If |secure| is false and |name| starts with either "`__Secure-`" or "`__Host-`",
     then return failure.
 1. Let |attributes| be a [=list=].

--- a/index.bs
+++ b/index.bs
@@ -1217,20 +1217,16 @@ run the following steps:
 
 1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
 1. Let |host| be |url|'s [=url/host=]
+1. Let |attributes| be a new [=list=].
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002D (`.`), then return failure.
     1. If |host| does not equal |domain| and
         |host| does not end with U+002D (`.`) followed by |domain|,
         then return failure.
-    1. Otherwise, set the cookie's |host-only-flag| to false.
-1. Otherwise, if |domain| is null, run these steps:
-    1. Set the cookie's |host-only-flag| to true.
-    1. Set |domain| to |host|.
+    1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
 1. If |secure| is false and |name| starts with either "`__Secure-`" or "`__Host-`",
     then return failure.
-1. Let |attributes| be a [=list=].
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
 1. [=list/Append=] \``Path`\`/|path| ([=encoded=]) to |attributes|.
 1. If |secure| is true, then [=list/append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:


### PR DESCRIPTION
### Description 
The following will cause different behaviors 
`domain : null` 
`domain: (new URL(self.location.href)).hostname`

Setting `null` which is the actual default means that it is locked toe the current domain and `host-only=flag` is set to false. 
Explicitly setting `domain` to `(new URL(self.location.href)).hostname` will set `host-only=true` and allow scope to span to subdomains as well.

### Reference 
[Cookie RFC](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-5.4)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/134.html" title="Last updated on Apr 8, 2020, 8:35 PM UTC (5b3e740)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/134/7d1d875...5b3e740.html" title="Last updated on Apr 8, 2020, 8:35 PM UTC (5b3e740)">Diff</a>