### PR TITLE
Remove `secure` flag from Modifications API 

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -154,7 +154,7 @@ because Web developers expect that the cookie change would be reflected in a
 
 ```javascript
 document.getElementById('opt-out-button').addEventListener('click', () => {
-  document.cookie = 'opt_out=1; Expires=Wed, 1 Jan 2025 00:00:00 GMT; :';
+  document.cookie = 'opt_out=1; Expires=Wed, 1 Jan 2025 00:00:00 GMT; Secure';
 });
 document.getElementById('opt-in-button').addEventListener('click', () => {
   // Cookies are deleted by setting their expiration dates in the past.

--- a/explainer.md
+++ b/explainer.md
@@ -154,7 +154,7 @@ because Web developers expect that the cookie change would be reflected in a
 
 ```javascript
 document.getElementById('opt-out-button').addEventListener('click', () => {
-  document.cookie = 'opt_out=1; Expires=Wed, 1 Jan 2025 00:00:00 GMT; Secure';
+  document.cookie = 'opt_out=1; Expires=Wed, 1 Jan 2025 00:00:00 GMT; :';
 });
 document.getElementById('opt-in-button').addEventListener('click', () => {
   // Cookies are deleted by setting their expiration dates in the past.
@@ -265,10 +265,7 @@ await cookieStore.set({
 
   // By default, domain is set to null which means the scope is locked at the current domain.
   domain: null,
-  path: '/',
-
-  // Creates secure cookies by default on secure origins.
-  secure: (new URL(self.location.href)).protocol === 'https:',
+  path: '/'
 });
 ```
 
@@ -428,12 +425,12 @@ matches the behavior of `document.cookie`.
 
 ### The Secure flag
 
-The modification API defaults the `secure` (HTTPS-only) flag to true for
-secure origins. This is an intentional difference from `document.cookie`,
+The modification API sets the `secure` (HTTPS-only) flag to true for
+all origins. This is an intentional difference from `document.cookie`,
 which always defaults to insecure cookies.
 
-The modification API disallows modifying (overwriting or deleting) a secure
-cookie from a non-secure origin, following a
+The modification API disallows modifying (overwriting or deleting) cookies
+from a non-secure origin, following a
 [recent proposal](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-alone-01).
 
 ### Names and Values

--- a/index.bs
+++ b/index.bs
@@ -357,10 +357,7 @@ await cookieStore.set({
 
   // By default, domain is set to null which means the scope is locked at the current domain.
   domain: null,
-  path: '/',
-
-  // Creates secure cookies by default on secure origins.
-  secure: true,
+  path: '/'
 });
 ```
 
@@ -581,7 +578,6 @@ dictionary CookieStoreSetOptions {
   DOMTimeStamp? expires = null;
   USVString? domain = null;
   USVString path = "/";
-  boolean secure = true;
   CookieSameSite sameSite = "strict";
 };
 
@@ -740,7 +736,6 @@ The <dfn method for=CookieStore>getAll(|options|)</dfn> method, when invoked, mu
         * Path: `/`
         * Domain: same as the domain of the current document or service worker's location
         * No expiry date
-        * Secure flag: set (cookie only transmitted over secure protocol)
         * SameSite: strict
 
 </div>
@@ -759,8 +754,7 @@ The <dfn method for=CookieStore>set(|name|, |value|, |options|)</dfn> method, wh
         |value|,
         |options|' {{CookieStoreSetOptions/expires}} dictionary member,
         |options|' {{CookieStoreSetOptions/domain}} dictionary member,
-        |options|' {{CookieStoreSetOptions/path}} dictionary member,
-        |options|' {{CookieStoreSetOptions/secure}} dictionary member, and
+        |options|' {{CookieStoreSetOptions/path}} dictionary member, and
         |options|' {{CookieStoreSetOptions/sameSite}} dictionary member.
     1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
     1. [=Resolve=] |p| with undefined.
@@ -782,8 +776,7 @@ The <dfn method for=CookieStore>set(|options|)</dfn> method, when invoked, must 
         |options|' {{CookieStoreSetExtraOptions/value}} dictionary member,
         |options|' {{CookieStoreSetOptions/expires}} dictionary member,
         |options|' {{CookieStoreSetOptions/domain}} dictionary member,
-        |options|' {{CookieStoreSetOptions/path}} dictionary member,
-        |options|' {{CookieStoreSetOptions/secure}} dictionary member, and
+        |options|' {{CookieStoreSetOptions/path}} dictionary member, and
         |options|' {{CookieStoreSetOptions/sameSite}} dictionary member.
     1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
     1. [=Resolve=] |p| with undefined.
@@ -1210,8 +1203,7 @@ To <dfn>set a cookie</dfn> with
 |value|,
 optional |expires|,
 |domain|,
-|path|,
-|secure| flag, and
+|path|, and
 |sameSite|,
 run the following steps:
 
@@ -1224,11 +1216,11 @@ run the following steps:
         |host| does not end with U+002D (`.`) followed by |domain|,
         then return failure.
     1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
-1. If |secure| is false and |name| starts with either "`__Secure-`" or "`__Host-`",
+1. If |name| starts with either "`__Secure-`" or "`__Host-`",
     then return failure.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
 1. [=list/Append=] \``Path`\`/|path| ([=encoded=]) to |attributes|.
-1. If |secure| is true, then [=list/append=] \``Secure`\`/\`\` to |attributes|.
+1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>
         : "{{CookieSameSite/none}}"
@@ -1272,10 +1264,9 @@ run the following steps:
     as long as it is in the past.
 
 1. Let |value| be the empty string.
-1. Let |secure| be true.
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
-    Note: The values for |value|, |secure|, and |sameSite| will not be persisted
+    Note: The values for |value|, and |sameSite| will not be persisted
     by this algorithm.
 
 1. Return the results of running [=set a cookie=] with

--- a/index.bs
+++ b/index.bs
@@ -1216,8 +1216,6 @@ run the following steps:
         |host| does not end with U+002D (`.`) followed by |domain|,
         then return failure.
     1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
-1. If |name| starts with either "`__Secure-`" or "`__Host-`",
-    then return failure.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
 1. [=list/Append=] \``Path`\`/|path| ([=encoded=]) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -1275,8 +1275,7 @@ run the following steps:
     |value|,
     |expires|,
     |domain|,
-    |path|,
-    |secure|, and
+    |path|, and
     |sameSite|.
 
 </div>


### PR DESCRIPTION
This change is based off https://github.com/WICG/cookie-store/issues/121, and removes `secure` option on Modifications API. Modifications API will only be able to write secure cookies.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/135.html" title="Last updated on May 15, 2020, 5:37 PM UTC (fe7817a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/135/7b808d7...fe7817a.html" title="Last updated on May 15, 2020, 5:37 PM UTC (fe7817a)">Diff</a>