### PR TITLE
Remove optional from CookieStoreGetOptions

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -219,9 +219,8 @@ In Document contexts, `await cookieStore.getAll()` is an equivalent of
 `document.cookie`.
 
 In other words, `get` and `getAll` take the same arguments, which can be
-* an optional dictionary of options
-* a name and an optional dictionary of options; in this case, the bag must not
-  contain the `name` properties
+* a name
+* a dictionary of options (optional for `getAll`)
 
 
 ### Read the cookies for a specific URL

--- a/index.bs
+++ b/index.bs
@@ -251,7 +251,7 @@ Both methods return [=promises=].
 Both methods take the same arguments, which can be either:
 
 * a name, or
-* a optional dictionary of options
+* a dictionary of options (optional for {{CookieStore/getAll()}})
 
 The {{CookieStore/get()}} method is essentially a form of {{CookieStore/getAll()}} that only returns the first result.
 
@@ -541,7 +541,7 @@ a [=tuple=] of <dfn>name</dfn>, <dfn>url</dfn>, and <dfn>matchType</dfn>.
  SecureContext]
 interface CookieStore : EventTarget {
   Promise<CookieListItem?> get(USVString name);
-  Promise<CookieListItem?> get(optional CookieStoreGetOptions options = {});
+  Promise<CookieListItem?> get(CookieStoreGetOptions options);
 
   Promise<CookieList> getAll(USVString name);
   Promise<CookieList> getAll(optional CookieStoreGetOptions options = {});
@@ -643,13 +643,12 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method steps are:
 1. Let |origin| be the [=current settings object=]'s [=/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. If |options|' {{CookieStoreGetOptions/url}} dictionary member is present, then run these steps:
-    1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with [=/this=]'s [=relevant settings object=]'s [=API base URL=].
-    1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
+1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with [=/this=]'s [=relevant settings object=]'s [=API base URL=].
+1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
         then return [=a promise rejected with=] a {{TypeError}}.
-    1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
+1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
         then return [=a promise rejected with=] a {{TypeError}}.
-    1. Set |url| to |parsed|.
+1. Set |url| to |parsed|.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
     1. Let |list| be the results of running [=query cookies=] with

--- a/index.bs
+++ b/index.bs
@@ -645,9 +645,9 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method steps are:
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
 1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with [=/this=]'s [=relevant settings object=]'s [=API base URL=].
 1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
-        then return [=a promise rejected with=] a {{TypeError}}.
+     then return [=a promise rejected with=] a {{TypeError}}.
 1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
-        then return [=a promise rejected with=] a {{TypeError}}.
+     then return [=a promise rejected with=] a {{TypeError}}.
 1. Set |url| to |parsed|.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:

--- a/index.bs
+++ b/index.bs
@@ -643,12 +643,13 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method steps are:
 1. Let |origin| be the [=current settings object=]'s [=/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be the [=current settings object=]'s [=creation URL=].
-1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with [=/this=]'s [=relevant settings object=]'s [=API base URL=].
-1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
-     then return [=a promise rejected with=] a {{TypeError}}.
-1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
-     then return [=a promise rejected with=] a {{TypeError}}.
-1. Set |url| to |parsed|.
+1. If |options|' {{CookieStoreGetOptions/url}} dictionary member is present, then run these steps:
+    1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|' {{CookieStoreGetOptions/url}} dictionary member with [=/this=]'s [=relevant settings object=]'s [=API base URL=].
+    1. If the [=current global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
+        then return [=a promise rejected with=] a {{TypeError}}.
+    1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
+        then return [=a promise rejected with=] a {{TypeError}}.
+    1. Set |url| to |parsed|.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
     1. Let |list| be the results of running [=query cookies=] with


### PR DESCRIPTION
Github issue: https://github.com/WICG/cookie-store/issues/140

**Before**
```
 Promise<CookieListItem?> get(optional CookieStoreGetOptions options = {});
```
**After**
```
 Promise<CookieListItem?> get(CookieStoreGetOptions options);
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ayuishii/cookie-store/pull/142.html" title="Last updated on Jun 2, 2020, 11:26 PM UTC (bc9814c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/142/5afd965...ayuishii:bc9814c.html" title="Last updated on Jun 2, 2020, 11:26 PM UTC (bc9814c)">Diff</a>