### PR TITLE
Remove `required` from CookieInit value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -592,7 +592,7 @@ dictionary CookieStoreDeleteOptions {
 };
 
 dictionary CookieListItem {
-  required USVString name;
+  USVString name;
   USVString value;
   USVString? domain;
   USVString path;

--- a/index.bs
+++ b/index.bs
@@ -578,7 +578,7 @@ enum CookieSameSite {
 
 dictionary CookieInit {
   required USVString name;
-  required USVString value;
+  USVString value;
   DOMTimeStamp? expires = null;
   USVString? domain = null;
   USVString path = "/";

--- a/index.bs
+++ b/index.bs
@@ -578,7 +578,7 @@ enum CookieSameSite {
 
 dictionary CookieInit {
   required USVString name;
-  USVString value;
+  required USVString value;
   DOMTimeStamp? expires = null;
   USVString? domain = null;
   USVString path = "/";
@@ -591,8 +591,14 @@ dictionary CookieStoreDeleteOptions {
   USVString path = "/";
 };
 
-dictionary CookieListItem : CookieInit {
-  boolean secure = true;
+dictionary CookieListItem {
+  required USVString name;
+  USVString value;
+  USVString? domain;
+  USVString path;
+  DOMTimeStamp? expires;
+  boolean secure;
+  CookieSameSite sameSite;
 }
 
 typedef sequence<CookieListItem> CookieList;


### PR DESCRIPTION
I bumped into an issue while trying to implement `required` for value, and thought it could be discussed here. 

Currently we spec that an `undefined` value is set for CookieListItem for a deleted change event CookieListItem described [here](https://wicg.github.io/cookie-store/#process-changes). Tested and verified [here](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/web_tests/external/wpt/cookie-store/cookieStore_event_delete.tentative.https.window.js;l=19?originalUrl=https:%2F%2Fcs.chromium.org%2F).

Would be acceptable to have this return an empty string instead of `undefined` or maybe to have a separate dict to add `required` to value string just to set(). 

Let me know if a different forum would be better.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/143.html" title="Last updated on Jun 5, 2020, 8:24 PM UTC (0b3f3b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/143/d6308dd...0b3f3b8.html" title="Last updated on Jun 5, 2020, 8:24 PM UTC (0b3f3b8)">Diff</a>