### PR TITLE
Revert "Remove optional from CookieStoreGetOptions"

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -219,8 +219,9 @@ In Document contexts, `await cookieStore.getAll()` is an equivalent of
 `document.cookie`.
 
 In other words, `get` and `getAll` take the same arguments, which can be
-* a name
-* a dictionary of options (optional for `getAll`)
+* an optional dictionary of options
+* a name and an optional dictionary of options; in this case, the bag must not
+  contain the `name` properties
 
 
 ### Read the cookies for a specific URL

--- a/index.bs
+++ b/index.bs
@@ -252,7 +252,7 @@ Both methods return [=promises=].
 Both methods take the same arguments, which can be either:
 
 * a name, or
-* a dictionary of options (optional for {{CookieStore/getAll()}})
+* a optional dictionary of options
 
 The {{CookieStore/get()}} method is essentially a form of {{CookieStore/getAll()}} that only returns the first result.
 
@@ -544,7 +544,7 @@ a [=tuple=] of <dfn>name</dfn>, <dfn>url</dfn>, and <dfn>matchType</dfn>.
  SecureContext]
 interface CookieStore : EventTarget {
   Promise<CookieListItem?> get(USVString name);
-  Promise<CookieListItem?> get(CookieStoreGetOptions options);
+  Promise<CookieListItem?> get(optional CookieStoreGetOptions options = {});
 
   Promise<CookieList> getAll(USVString name);
   Promise<CookieList> getAll(optional CookieStoreGetOptions options = {});


### PR DESCRIPTION
IDL rules disallows required dictionaries that don't have any required fields.
https://github.com/w3c/webidl2.js/blob/gh-pages/README.md#errors
