### PR TITLE
Add missing semicolon after CookieListItem dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -599,7 +599,7 @@ dictionary CookieListItem {
   DOMTimeStamp? expires;
   boolean secure;
   CookieSameSite sameSite;
-}
+};
 
 typedef sequence<CookieListItem> CookieList;
 </xmp>


### PR DESCRIPTION
Discovered in https://github.com/web-platform-tests/wpt/pull/23957.