### PR TITLE
Remove issue on non-persistent session cookies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -493,9 +493,6 @@ When any of the following conditions occur for a [=cookie store=], perform the s
 * A user agent evicts expired [=cookies=] from the [=cookie store=].
 * A user agent removes excess [=cookies=] from the [=cookie store=].
 
-Issue: How about when "the current session is over" for non-persistent cookies?
-
-
 <!-- ============================================================ -->
 ## Extensions to Service Worker ## {#service-worker-extensions}
 <!-- ============================================================ -->


### PR DESCRIPTION
Removing issue since it does not seem to trigger cookie change when session is over for non-persistent cookies. [
Session cookie cleanup code](https://source.chromium.org/chromium/chromium/src/+/master:services/network/session_cleanup_cookie_store.cc;l=52;drc=aeb70b905ac38796b9801ec6a0230e71005c8b6b;bpv=1;bpt=1).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ayuishii/cookie-store/pull/177.html" title="Last updated on Sep 15, 2020, 12:11 AM UTC (53356d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/177/450c023...ayuishii:53356d2.html" title="Last updated on Sep 15, 2020, 12:11 AM UTC (53356d2)">Diff</a>