### PR TITLE
Update `Path` Algorithm to match Explainer & Tests

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1110,8 +1110,8 @@ run the following steps:
     1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
 1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+0002F (`/`), then return failure.
-    1. If |path| does not end with U+0002F (`/`), append U+0002F (`/`) to |path|.
+    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
 1. [=list/Append=] \``Path`\`/|path| ([=encoded=]) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
@@ -1152,8 +1152,8 @@ To <dfn>delete a cookie</dfn> with
 run the following steps:
 
 1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+0002F (`/`), then return failure.
-    1. If |path| does not end with U+0002F (`/`), append U+0002F (`/`) to |path|.
+    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
     
 1. Let |expires| be the earliest representable date represented [=as a timestamp=].
 

--- a/index.bs
+++ b/index.bs
@@ -1109,6 +1109,9 @@ run the following steps:
         then return failure.
     1. [=list/Append=] \``Domain`\`/|domain| ([=encoded=]) to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
+1. If |path| is not null, then run these steps:
+    1. If |path| does not start with U+0002F (`/`), then return failure.
+    1. If |path| does not end with U+0002F (`/`), append U+0002F (`/`) to |path|.
 1. [=list/Append=] \``Path`\`/|path| ([=encoded=]) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:

--- a/index.bs
+++ b/index.bs
@@ -1151,6 +1151,10 @@ To <dfn>delete a cookie</dfn> with
 |path|,
 run the following steps:
 
+1. If |path| is not null, then run these steps:
+    1. If |path| does not start with U+0002F (`/`), then return failure.
+    1. If |path| does not end with U+0002F (`/`), append U+0002F (`/`) to |path|.
+    
 1. Let |expires| be the earliest representable date represented [=as a timestamp=].
 
     Note: The exact value of |expires| is not important for the purposes of this algorithm,


### PR DESCRIPTION
A leading `/` is required in paths for setting & deleting a cookie.
This is part of the explainer and has tests to validate this, but was not part of the spec.
This change adds this to the spec.

https://github.com/WICG/cookie-store/issues/188


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/192.html" title="Last updated on Apr 26, 2021, 8:26 PM UTC (fceaff6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/192/62089ad...fceaff6.html" title="Last updated on Apr 26, 2021, 8:26 PM UTC (fceaff6)">Diff</a>