### PR TITLE
Fix and simplify cookie writing example

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -259,11 +259,11 @@ await cookieStore.set({
   expires: null,  // session cookie
 
   // By default, cookies are scoped at the current domain.
-  domain: (new URL(self.location.href)).domain,
+  domain: self.location.host,
   path: '/',
 
   // Creates secure cookies by default on secure origins.
-  secure: (new URL(self.location.href)).protocol === 'https:',
+  secure: self.location.protocol === 'https:',
   httpOnly: false,
 });
 ```


### PR DESCRIPTION
1. `URL` interface has no `domain` property but `host`
2. `new URL(self.location.href)` is not needed since `self.location` has similar interface as `URL` (see https://html.spec.whatwg.org/multipage/history.html#location, https://html.spec.whatwg.org/multipage/workers.html#workerlocation)