### PR TITLE
Allow tab characters in cookies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1103,7 +1103,7 @@ optional |expires|,
 |sameSite|,
 run the following steps:
 
-1. If |name|, |value|, |domain|, or |path| contain U+003B (`;`), any [=C0 control=] character, or U+007F, then return failure.
+1. If |name| or |value| contain U+003B (`;`), any [=C0 control=] character except U+0009 (the horizontal tab character), or U+007F, then return failure.
 1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
 1. If |name|'s [=string/length=] is 0 and |value|'s [=string/length=] is 0, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.

--- a/index.bs
+++ b/index.bs
@@ -1104,6 +1104,9 @@ optional |expires|,
 run the following steps:
 
 1. If |name| or |value| contain U+003B (`;`), any [=C0 control=] character except U+0009 (the horizontal tab character), or U+007F, then return failure.
+
+    ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.
+
 1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
 1. If |name|'s [=string/length=] is 0 and |value|'s [=string/length=] is 0, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.


### PR DESCRIPTION
Fixes #203 - Allow tab characters in cookies

~~Also, applies the invalid character checks to all other attribute values as well for added clarity (even if they are less likely to contain invalid characters due to other restrictions on the types for those)~~


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/recvfrom/cookie-store/pull/204.html" title="Last updated on Aug 13, 2021, 9:52 PM UTC (cd44859)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/204/2fba1a5...recvfrom:cd44859.html" title="Last updated on Aug 13, 2021, 9:52 PM UTC (cd44859)">Diff</a>