### PR TITLE
Update DOMTimeStamp to EpochTimeStamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -496,7 +496,7 @@ enum CookieSameSite {
 dictionary CookieInit {
   required USVString name;
   required USVString value;
-  DOMTimeStamp? expires = null;
+  EpochTimeStamp? expires = null;
   USVString? domain = null;
   USVString path = "/";
   CookieSameSite sameSite = "strict";
@@ -513,7 +513,7 @@ dictionary CookieListItem {
   USVString value;
   USVString? domain;
   USVString path;
-  DOMTimeStamp? expires;
+  EpochTimeStamp? expires;
   boolean secure;
   CookieSameSite sameSite;
 };
@@ -1011,7 +1011,7 @@ Note: This is the same representation used for [=time values=] in [[ECMAScript]]
 
 
 <div algorithm>
-To <dfn>date serialize</dfn> a {{DOMTimeStamp}} |millis|,
+To <dfn>date serialize</dfn> a {{EpochTimeStamp}} |millis|,
 let |dateTime| be the date and time |millis| milliseconds after 00:00:00 UTC, 1 January 1970
 (assuming that there are exactly 86,400,000 milliseconds per day),
 and return a [=byte sequence=] corresponding to the closest `cookie-date` representation of |dateTime| according to [[RFC6265bis#section-5.1.1|Cookies: HTTP State Management Mechanism §Dates]].


### PR DESCRIPTION
This typedef has moved from IDL and been renamed: https://w3c.github.io/hr-time/#dom-epochtimestamp


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/208.html" title="Last updated on Jul 6, 2022, 4:48 PM UTC (6ab7914)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/208/e1a1cfa...6ab7914.html" title="Last updated on Jul 6, 2022, 4:48 PM UTC (6ab7914)">Diff</a>