### PR TITLE
Normative: Change use of EpochTimeStamp to DOMHighResTimeStamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -506,7 +506,7 @@ enum CookieSameSite {
 dictionary CookieInit {
   required USVString name;
   required USVString value;
-  EpochTimeStamp? expires = null;
+  DOMHighResTimeStamp? expires = null;
   USVString? domain = null;
   USVString path = "/";
   CookieSameSite sameSite = "strict";
@@ -523,7 +523,7 @@ dictionary CookieListItem {
   USVString value;
   USVString? domain;
   USVString path;
-  EpochTimeStamp? expires;
+  DOMHighResTimeStamp? expires;
   boolean secure;
   CookieSameSite sameSite;
 };
@@ -1021,7 +1021,7 @@ Note: This is the same representation used for [=time values=] in [[ECMAScript]]
 
 
 <div algorithm>
-To <dfn>date serialize</dfn> a {{EpochTimeStamp}} |millis|,
+To <dfn>date serialize</dfn> a {{DOMHighResTimeStamp}} |millis|,
 let |dateTime| be the date and time |millis| milliseconds after 00:00:00 UTC, 1 January 1970
 (assuming that there are exactly 86,400,000 milliseconds per day),
 and return a [=byte sequence=] corresponding to the closest `cookie-date` representation of |dateTime| according to [[RFC6265bis#section-5.1.1]]<!-- Dates -->.


### PR DESCRIPTION
EpochTimeStamp is a typedef for unsigned long long and deprecated, and DOMHighResTimeStamp is a typedef for double and the preferred type going forward. Semantics are the same.

Resolves #205


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/214.html" title="Last updated on Feb 18, 2023, 12:57 AM UTC (af6c826)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/214/5dfe3db...af6c826.html" title="Last updated on Feb 18, 2023, 12:57 AM UTC (af6c826)">Diff</a>