### PR TITLE
Normative: get()'s promise should resolve to null, not undefined

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -559,7 +559,7 @@ The <dfn method for=CookieStore>get(|name|)</dfn> method steps are:
     1. Let |list| be the results of running [=query cookies=] with
         |url| and |name|.
     1. If |list| is failure, then [=/reject=] |p| with a {{TypeError}} and abort these steps.
-    1. If |list| [=list/is empty=], then [=/resolve=] |p| with undefined.
+    1. If |list| [=list/is empty=], then [=/resolve=] |p| with null.
     1. Otherwise, [=/resolve=] |p| with the first item of |list|.
 1. Return |p|.
 
@@ -586,7 +586,7 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method steps are:
         |url| and
         |options|["{{CookieStoreGetOptions/name}}"] (if present).
     1. If |list| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
-    1. If |list| [=list/is empty=], then [=/resolve=] |p| with undefined.
+    1. If |list| [=list/is empty=], then [=/resolve=] |p| with null.
     1. Otherwise, [=/resolve=] |p| with the first item of |list|.
 1. Return |p|.
 


### PR DESCRIPTION
The spec and tests were inconsistent:

* In the spec's IDL, the inner type of the promise returned by get() is nullable.

* In the spec's prose, the steps call for resolving the promise with undefined.

* In WPT, the tests[1] assert that the promise is resolved with null.

The Chromium implementation[2] matched the tests, not the spec prose.

Investigation documented in #210 indicates it is likely not web-compatible to make this change purely for idealistic reasons.

Resolves #210.

[1] example: https://github.com/web-platform-tests/wpt/blob/master/cookie-store/cookieStore_delete_arguments.https.any.js

[2] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/cookie_store/cookie_store.cc;l=482


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/217.html" title="Last updated on Jul 7, 2023, 8:50 PM UTC (2641c90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/217/837f4f2...2641c90.html" title="Last updated on Jul 7, 2023, 8:50 PM UTC (2641c90)">Diff</a>