### PR TITLE
Add '[SecureContext]` tags to the interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -895,7 +895,8 @@ The <dfn method for=CookieStoreManager>unsubscribe(|subscriptions|)</dfn> method
 The {{ServiceWorkerRegistration}} interface is extended to give access to a {{CookieStoreManager}} via {{ServiceWorkerRegistration/cookies}} which provides the interface for subscribing to cookie changes.
 
 <xmp class=idl>
-[Exposed=(ServiceWorker,Window)]
+[Exposed=(ServiceWorker,Window),
+ SecureContext]
 partial interface ServiceWorkerRegistration {
   [SameObject] readonly attribute CookieStoreManager cookies;
 };
@@ -964,7 +965,8 @@ cookie changes have occurred which match the [=Service Worker=]'s
 Note: {{ExtendableEvent}} is used as the ancestor interface for all events in [=Service Workers=] so that the worker itself can be kept alive while the async operations are performed.
 
 <xmp class=idl>
-[Exposed=ServiceWorker]
+[Exposed=ServiceWorker,
+ SecureContext]
 interface ExtendableCookieChangeEvent : ExtendableEvent {
   constructor(DOMString type, optional ExtendableCookieChangeEventInit eventInitDict = {});
   [SameObject] readonly attribute FrozenArray<CookieListItem> changed;
@@ -1007,6 +1009,7 @@ The <dfn attribute for=Window>cookieStore</dfn> getter steps are to return [=/th
 <!-- ============================================================ -->
 
 <xmp class=idl>
+[SecureContext]
 partial interface ServiceWorkerGlobalScope {
   [SameObject] readonly attribute CookieStore cookieStore;
 

--- a/index.bs
+++ b/index.bs
@@ -895,8 +895,7 @@ The <dfn method for=CookieStoreManager>unsubscribe(|subscriptions|)</dfn> method
 The {{ServiceWorkerRegistration}} interface is extended to give access to a {{CookieStoreManager}} via {{ServiceWorkerRegistration/cookies}} which provides the interface for subscribing to cookie changes.
 
 <xmp class=idl>
-[Exposed=(ServiceWorker,Window),
- SecureContext]
+[Exposed=(ServiceWorker,Window)]
 partial interface ServiceWorkerRegistration {
   [SameObject] readonly attribute CookieStoreManager cookies;
 };
@@ -1009,7 +1008,6 @@ The <dfn attribute for=Window>cookieStore</dfn> getter steps are to return [=/th
 <!-- ============================================================ -->
 
 <xmp class=idl>
-[SecureContext]
 partial interface ServiceWorkerGlobalScope {
   [SameObject] readonly attribute CookieStore cookieStore;
 


### PR DESCRIPTION
- addresses https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment some syntax sections are missing the `[SecureContext]` tags so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/ed/idl/cookie-store.idl#L92).

The feature has been [marked secure in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableCookieChangeEvent). 

The PR adds the tags to the remaining interfaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OnkarRuikar/cookie-store/pull/224.html" title="Last updated on Feb 5, 2024, 2:58 PM UTC (8044570)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/224/880b5ea...OnkarRuikar:8044570.html" title="Last updated on Feb 5, 2024, 2:58 PM UTC (8044570)">Diff</a>