### PR TITLE
Fix `Set A Cookie` Algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -682,12 +682,20 @@ The <dfn method for=CookieStore>set(|name|, |value|)</dfn> method steps are:
 1. Let |origin| be |settings|'s [=environment settings object/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be |settings|'s [=environment/creation URL=].
+1. Let |domain| be null.
+1. Let |path| be "/".
+1. Let |sameSite| be {{CookieSameSite/strict}}.
+1. Let |partitioned| be false.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
     1. Let |r| be the result of running [=set a cookie=] with
         |url|,
         |name|,
-        |value|.
+        |value|,
+        |domain|,
+        |path|,
+        |sameSite|, and
+        |partitioned|.
     1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
     1. [=/Resolve=] |p| with undefined.
 1. Return |p|.
@@ -1148,12 +1156,11 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+002F (`/`), then return failure.
-    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
-    1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
-    1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
-    1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. If |path| does not start with U+002F (`/`), then return failure.
+1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
+1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
+1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
+1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>

--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 <pre class=link-defaults>
 spec:service-workers; type:dfn; for:/; text:service worker
 spec:service-workers; type:dfn; for:/; text:service worker registration
+spec:dom; type:dfn; text:document
+spec:webidl; type:exception; text:TypeError
 </pre>
 
 <style>

--- a/index.bs
+++ b/index.bs
@@ -43,8 +43,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 <pre class=link-defaults>
 spec:service-workers; type:dfn; for:/; text:service worker
 spec:service-workers; type:dfn; for:/; text:service worker registration
-spec:dom; type:dfn; text:document
-spec:webidl; type:exception; text:TypeError
 </pre>
 
 <style>


### PR DESCRIPTION
Addresses issue: https://github.com/WICG/cookie-store/issues/227

* Updates "Set a Cookie" algorithm to not null check `path` as it should always be populated
* Updates  `set` method to call algorithm with all non-optional parameters


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ayuishii/cookie-store/pull/231.html" title="Last updated on Jun 7, 2024, 11:54 PM UTC (8e63f45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/231/7f81399...ayuishii:8e63f45.html" title="Last updated on Jun 7, 2024, 11:54 PM UTC (8e63f45)">Diff</a>