### PR TITLE
Fix code point for '.' - it's U+002E not U+002D

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1140,9 +1140,9 @@ run the following steps:
 1. Let |host| be |url|'s [=url/host=]
 1. Let |attributes| be a new [=/list=].
 1. If |domain| is not null, then run these steps:
-    1. If |domain| starts with U+002D (`.`), then return failure.
+    1. If |domain| starts with U+002E (`.`), then return failure.
     1. If |host| does not equal |domain| and
-        |host| does not end with U+002D (`.`) followed by |domain|,
+        |host| does not end with U+002E (`.`) followed by |domain|,
         then return failure.
     1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |domain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.


### PR DESCRIPTION
Thanks @annevk for noticing!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/pull/235.html" title="Last updated on Jul 12, 2024, 6:03 PM UTC (6ab37df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/235/7f81399...6ab37df.html" title="Last updated on Jul 12, 2024, 6:03 PM UTC (6ab37df)">Diff</a>