### PR TITLE
The delete cookie algorithm should not overwrite a cookie with an empty value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1210,7 +1210,7 @@ run the following steps:
     Note: The exact value of |expires| is not important for the purposes of this algorithm,
     as long as it is in the past.
 
-1. Let |value| be the empty string.
+1. Let |value| be any non-empty user-agent supplied string.
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
     Note: The values for |value|, and |sameSite| will not be persisted

--- a/index.bs
+++ b/index.bs
@@ -1210,7 +1210,7 @@ run the following steps:
     Note: The exact value of |expires| is not important for the purposes of this algorithm,
     as long as it is in the past.
 
-1. Let |value| be any non-empty user-agent supplied string.
+1. Let |value| be any non-empty [=implementation-defined=] string.
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
     Note: The values for |value|, and |sameSite| will not be persisted


### PR DESCRIPTION
Per https://github.com/WICG/cookie-store/issues/252 we should rework the spec so the delete cookie algorithm does not overwrite the cookie with an empty value. 

Otherwise, there is no way to delete a nameless cookie since the set cookie algorithm would fail for a nameless, valueless cookie.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/254.html" title="Last updated on May 5, 2025, 5:22 PM UTC (20dc427)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/254/37fb6f5...aamuley:20dc427.html" title="Last updated on May 5, 2025, 5:22 PM UTC (20dc427)">Diff</a>