### PR TITLE
Set cookie should parse domain into consistent format before setting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1155,7 +1155,7 @@ run the following steps:
     1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
     1. If |domain| [=is a registrable domain suffix of or is equal to|is not a registrable domain suffix of and is not equal to=] |host|, then return failure.
     1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
-    1. Assert: |parsedDomain| is not a failure.
+    1. Assert: |parsedDomain| is not failure.
     1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -710,16 +710,14 @@ The <dfn method for=CookieStore>set(|options|)</dfn> method steps are:
 1. Let |origin| be |settings|'s [=environment settings object/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be |settings|'s [=environment/creation URL=].
-1. Let |domain| be null.
-1. If |options|["{{CookieStoreSetOptions/domain}}"] is present, set |domain| to the result of [=host parser|host parsing=] |options|["{{CookieStoreSetOptions/domain}}"].
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
     1. Let |r| be the result of running [=set a cookie=] with
-        |domain|,
         |url|,
         |options|["{{CookieInit/name}}"],
         |options|["{{CookieInit/value}}"],
         |options|["{{CookieInit/expires}}"],
+        |options|["{{CookieInit/domain}}"],
         |options|["{{CookieInit/path}}"],
         |options|["{{CookieInit/sameSite}}"], and
         |options|["{{CookieInit/partitioned}}"].
@@ -1152,10 +1150,11 @@ run the following steps:
 1. Let |attributes| be a new [=/list=].
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002E (`.`), then return failure.
-    1. If |host| does not equal |domain| and
-        |host| does not end with U+002E (`.`) followed by |domain|,
+    1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
+    1. If |host| does not equal |parsedDomain| and
+        |host| does not end with U+002E (`.`) followed by |parsedDomain|,
         then return failure.
-    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |domain|.
+    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -1151,6 +1151,7 @@ run the following steps:
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002E (`.`), then return failure.
     1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
+    1. If |parsedDomain| is a failure, then return failure.
     1. If |host| does not equal |parsedDomain| and
         |host| does not end with U+002E (`.`) followed by |parsedDomain|,
         then return failure.

--- a/index.bs
+++ b/index.bs
@@ -1154,7 +1154,9 @@ run the following steps:
     1. If |domain| starts with U+002E (.), then return failure.
     1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
     1. If |domain| [=is a registrable domain suffix of or is equal to|is not a registrable domain suffix of and is not equal to=] |host|, then return failure.
-    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |domain|.
+    1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
+    1. If |parsedDomain| is a failure, then return failure.
+    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -1155,7 +1155,7 @@ run the following steps:
     1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
     1. If |domain| [=is a registrable domain suffix of or is equal to|is not a registrable domain suffix of and is not equal to=] |host|, then return failure.
     1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
-    1. If |parsedDomain| is a failure, then return failure.
+    1. Assert: |parsedDomain| is not a failure.
     1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -710,14 +710,16 @@ The <dfn method for=CookieStore>set(|options|)</dfn> method steps are:
 1. Let |origin| be |settings|'s [=environment settings object/origin=].
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be |settings|'s [=environment/creation URL=].
+1. Let |domain| be null.
+1. If |options|["{{CookieStoreSetOptions/domain}}"] is present, set |domain| to the result of [=host parser|host parsing=] |options|["{{CookieStoreSetOptions/domain}}"].
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
     1. Let |r| be the result of running [=set a cookie=] with
+        |domain|,
         |url|,
         |options|["{{CookieInit/name}}"],
         |options|["{{CookieInit/value}}"],
         |options|["{{CookieInit/expires}}"],
-        |options|["{{CookieInit/domain}}"],
         |options|["{{CookieInit/path}}"],
         |options|["{{CookieInit/sameSite}}"], and
         |options|["{{CookieInit/partitioned}}"].

--- a/index.bs
+++ b/index.bs
@@ -1150,12 +1150,8 @@ run the following steps:
 1. Let |attributes| be a new [=/list=].
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002E (`.`), then return failure.
-    1. Let |parsedDomain| be the result of [=host parser|host parsing=] |domain|.
-    1. If |parsedDomain| is a failure, then return failure.
-    1. If |host| does not equal |parsedDomain| and
-        |host| does not end with U+002E (`.`) followed by |parsedDomain|,
-        then return failure.
-    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
+    1. If |domain| [=is a registrable domain suffix of or is equal to|is not a registrable domain suffix of and is not equal to=] |host|, then return failure.
+    1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |domain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.


### PR DESCRIPTION
As discussed in #250, we should run the `domain` option through https://url.spec.whatwg.org/#concept-host-parser to ensure the domain is in a consistent and expected shape.

Will be adding WPTs to ensure there is coverage for various host types: https://chromium-review.googlesource.com/c/chromium/src/+/6613211


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/masnoble/cookie-store/pull/256.html" title="Last updated on Jun 11, 2025, 6:31 PM UTC (bf376a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/256/9570d80...masnoble:bf376a3.html" title="Last updated on Jun 11, 2025, 6:31 PM UTC (bf376a3)">Diff</a>