### PR TITLE
Do not append / to end of Path attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1157,11 +1157,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| does not start with U+002F (`/`), then return failure.
-1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
-1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
-1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
-1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. If |path| is not null, then run these steps:
+    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
+    1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
+    1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. Otherwise, if |path| is null, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>
@@ -1201,10 +1202,6 @@ To <dfn>delete a cookie</dfn> with
 |path|, and
 |partitioned|
 run the following steps:
-
-1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+002F (`/`), then return failure.
-    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
 
 1. Let |expires| be the earliest representable date represented [=as a timestamp=].
 

--- a/index.bs
+++ b/index.bs
@@ -1157,12 +1157,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is not null, then run these steps:
+1. If |path| is not null:
     1. If |path| does not start with U+002F (`/`), then return failure.
     1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
-1. Otherwise, if |path| is null, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
+1. Otherwise, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>


### PR DESCRIPTION
Per #244, we should stop appending "/" to the end of a Path if it is omitted. This change still maintains "/" as the default path if a path is not specified. 

Will be updating the WPTs in https://chromium-review.googlesource.com/c/chromium/src/+/6520094

cc @DCtheTall


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/258.html" title="Last updated on May 12, 2025, 5:29 PM UTC (abe5944)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/258/2e05e4a...aamuley:abe5944.html" title="Last updated on May 12, 2025, 5:29 PM UTC (abe5944)">Diff</a>