### PR TITLE
Specify "__Host-" and "__Secure-" prefix failures

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1157,11 +1157,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| does not start with U+002F (`/`), then return failure.
-1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
-1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
-1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
-1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. If |path| is not null, then run these steps:
+    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
+    1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
+    1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. Otherwise, if |path| is null, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>
@@ -1201,10 +1202,6 @@ To <dfn>delete a cookie</dfn> with
 |path|, and
 |partitioned|
 run the following steps:
-
-1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+002F (`/`), then return failure.
-    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
 
 1. Let |expires| be the earliest representable date represented [=as a timestamp=].
 

--- a/index.bs
+++ b/index.bs
@@ -1144,7 +1144,7 @@ run the following steps:
 1. If |name|'s [=string/length=] is 0:
     1. If |value| contains U+003D (`=`), then return failure.
     1. If |value|'s [=string/length=] is 0, then return failure.
-    1. If |value|, [=byte-lowercased=], [=byte sequence/starts with=] `__host-` or `__secure-` then return failure. 
+    1. If |value|, [=byte-lowercased=], [=byte sequence/starts with=] `__host-` or `__secure-`, then return failure. 
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.
 1. Let |encodedValue| be the result of [=UTF-8 encode|UTF-8 encoding=] |value|.
 1. If the [=byte sequence=] [=byte sequence/length=] of |encodedName| plus the [=byte sequence=] [=byte sequence/length=] of |encodedValue| is greater than the <a for=cookie>maximum name/value pair size</a>, then return failure.

--- a/index.bs
+++ b/index.bs
@@ -1141,8 +1141,10 @@ run the following steps:
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.
 
-1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
-1. If |name|'s [=string/length=] is 0 and |value|'s [=string/length=] is 0, then return failure.
+1. If |name|'s [=string/length=] is 0:
+    1. If |value| contains U+003D (`=`), then return failure.
+    1. If |value|'s [=string/length=] is 0, then return failure.
+    1. If |value|, [=byte-lowercased=], [=byte sequence/starts with=] `__host-` or `__secure-` then return failure. 
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.
 1. Let |encodedValue| be the result of [=UTF-8 encode|UTF-8 encoding=] |value|.
 1. If the [=byte sequence=] [=byte sequence/length=] of |encodedName| plus the [=byte sequence=] [=byte sequence/length=] of |encodedValue| is greater than the <a for=cookie>maximum name/value pair size</a>, then return failure.
@@ -1150,6 +1152,7 @@ run the following steps:
 1. Let |attributes| be a new [=/list=].
 1. If |domain| is not null, then run these steps:
     1. If |domain| starts with U+002E (`.`), then return failure.
+    1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] `__host-`, then return failure.
     1. If |host| does not equal |domain| and
         |host| does not end with U+002E (`.`) followed by |domain|,
         then return failure.
@@ -1159,6 +1162,7 @@ run the following steps:
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
 1. If |path| is not null:
     1. If |path| does not start with U+002F (`/`), then return failure.
+    1. If |path| is not U+002F (`/`), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] `__host-`, then return failure. 
     1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.

--- a/index.bs
+++ b/index.bs
@@ -1157,12 +1157,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is not null, then run these steps:
+1. If |path| is not null:
     1. If |path| does not start with U+002F (`/`), then return failure.
     1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
-1. Otherwise, if |path| is null, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
+1. Otherwise, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>


### PR DESCRIPTION
Per https://github.com/WICG/cookie-store/issues/248 add the cases where the CookieStore set algorithm would not resolve because of the prefix requirements to the spec. This is tested in [the set arguments wpt](https://github.com/web-platform-tests/wpt/blob/df1e48b497cc5dd19ba825ff273c5462b7962c87/cookie-store/cookieStore_set_arguments.https.any.js#L363) and [the special names wpt](https://github.com/web-platform-tests/wpt/blob/c9360813788a6f9d5ace7b00b18d170fc66f9d15/cookie-store/cookieStore_special_names.https.any.js)

Should this pr additionally change any language in https://wicg.github.io/cookie-store/#prefixes?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/259.html" title="Last updated on May 21, 2025, 5:24 PM UTC (12d9ea9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/259/abae748...aamuley:12d9ea9.html" title="Last updated on May 21, 2025, 5:24 PM UTC (12d9ea9)">Diff</a>