### PR TITLE
fix codepoints to follow infra formatting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1137,11 +1137,11 @@ optional |expires|,
 |partitioned|
 run the following steps:
 
-1. If |name| or |value| contain U+003B (`;`), any [=C0 control=] character except U+0009 (the horizontal tab character), or U+007F, then return failure.
+1. If |name| or |value| contain U+003B (;), any [=C0 control=] character except U+0009 TAB, or U+007F DELETE, then return failure.
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.
 
-1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (`=`), then return failure.
+1. If |name|'s [=string/length=] is 0 and |value| contains U+003D (=), then return failure.
 1. If |name|'s [=string/length=] is 0 and |value|'s [=string/length=] is 0, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.
 1. Let |encodedValue| be the result of [=UTF-8 encode|UTF-8 encoding=] |value|.
@@ -1149,20 +1149,20 @@ run the following steps:
 1. Let |host| be |url|'s [=url/host=]
 1. Let |attributes| be a new [=/list=].
 1. If |domain| is not null, then run these steps:
-    1. If |domain| starts with U+002E (`.`), then return failure.
+    1. If |domain| starts with U+002E (.), then return failure.
     1. If |host| does not equal |domain| and
-        |host| does not end with U+002E (`.`) followed by |domain|,
+        |host| does not end with U+002E (.) followed by |domain|,
         then return failure.
     1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |domain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
 1. If |path| is not null:
-    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. If |path| does not start with U+002F (/), then return failure.
     1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
-1. Otherwise, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
+1. Otherwise, [=list/append=] \``Path`\`/ U+002F (/) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>


### PR DESCRIPTION
the codepoints in the spec were formatted as (`<code>`) which doesnt follow [infra](https://infra.spec.whatwg.org/#code-points). This pr also adjusts the codepoint names to be the ascii uppercase representations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/260.html" title="Last updated on May 22, 2025, 1:53 PM UTC (0660616)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/260/abae748...aamuley:0660616.html" title="Last updated on May 22, 2025, 1:53 PM UTC (0660616)">Diff</a>