### PR TITLE
Only use implementation defined value for deleting nameless cookies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1209,7 +1209,9 @@ run the following steps:
     as long as it is in the past.
 
 1. Let |value| be the empty string. 
+
 1. If |name|'s [=string/length=] is 0, then set |value| to any non-empty [=implementation-defined=] string.
+
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
     Note: The values for |value|, and |sameSite| will not be persisted

--- a/index.bs
+++ b/index.bs
@@ -1157,11 +1157,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| does not start with U+002F (`/`), then return failure.
-1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
-1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
-1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
-1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. If |path| is not null:
+    1. If |path| does not start with U+002F (`/`), then return failure.
+    1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
+    1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
+    1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
+1. Otherwise, [=list/append=] \``Path`\`/ U+002F (`/`) to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>
@@ -1201,10 +1202,6 @@ To <dfn>delete a cookie</dfn> with
 |path|, and
 |partitioned|
 run the following steps:
-
-1. If |path| is not null, then run these steps:
-    1. If |path| does not start with U+002F (`/`), then return failure.
-    1. If |path| does not end with U+002F (`/`), then append U+002F (`/`) to |path|.
 
 1. Let |expires| be the earliest representable date represented [=as a timestamp=].
 

--- a/index.bs
+++ b/index.bs
@@ -1208,8 +1208,8 @@ run the following steps:
     Note: The exact value of |expires| is not important for the purposes of this algorithm,
     as long as it is in the past.
 
-1. If |name|'s [=string/length=] is 0, let |value| be any non-empty [=implementation-defined=] string.
-1. Otherwise, let |value| be the empty string. 
+1. Let |value| be the empty string. 
+1. If |name|'s [=string/length=] is 0, then set |value| to any non-empty [=implementation-defined=] string.
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
     Note: The values for |value|, and |sameSite| will not be persisted

--- a/index.bs
+++ b/index.bs
@@ -1208,7 +1208,8 @@ run the following steps:
     Note: The exact value of |expires| is not important for the purposes of this algorithm,
     as long as it is in the past.
 
-1. Let |value| be any non-empty [=implementation-defined=] string.
+1. If |name|'s [=string/length=] is 0, let |value| be any non-empty [=implementation-defined=] string.
+1. Otherwise, let |value| be the empty string. 
 1. Let |sameSite| be "{{CookieSameSite/strict}}".
 
     Note: The values for |value|, and |sameSite| will not be persisted


### PR DESCRIPTION
This accounts for the case where the name is the maximum size and a cookie's value must be 0B.  https://github.com/WICG/cookie-store/issues/252 

WPT for this will be added in https://chromium-review.googlesource.com/c/chromium/src/+/6604039


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/261.html" title="Last updated on May 30, 2025, 4:39 PM UTC (6a2b640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/261/abae748...aamuley:6a2b640.html" title="Last updated on May 30, 2025, 4:39 PM UTC (6a2b640)">Diff</a>