### PR TITLE
Disallow '=' in cookie names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1141,6 +1141,7 @@ run the following steps:
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.
 
+1. If |name| contains U+003D (=), then return failure.
 1. If |name|'s [=string/length=] is 0:
     1. If |value| contains U+003D (=), then return failure.
     1. If |value|'s [=string/length=] is 0, then return failure.


### PR DESCRIPTION
This aligns the spec with existing browser behavior of disallowing U+003D (`=`) in cookie names.

Resolves #201


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jalonthomas/cookie-store/pull/264.html" title="Last updated on Jul 2, 2025, 6:55 PM UTC (3a806a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/264/3184df5...jalonthomas:3a806a7.html" title="Last updated on Jul 2, 2025, 6:55 PM UTC (3a806a7)">Diff</a>