### PR TITLE
exclude fragments when comparing urls in cookieStore.get/getAll(options) 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -581,7 +581,7 @@ The <dfn method for=CookieStore>get(|options|)</dfn> method steps are:
 1. If |options| is empty, then return [=a promise rejected with=] a {{TypeError}}.
 1. If |options|["{{CookieStoreGetOptions/url}}"] is present, then run these steps:
     1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
-    1. If [=/this=]'s [=/relevant global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
+    1. If [=/this=]'s [=/relevant global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url| with [=url/equals/exclude fragments=] set to true,
         then return [=a promise rejected with=] a {{TypeError}}.
     1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
         then return [=a promise rejected with=] a {{TypeError}}.
@@ -639,7 +639,7 @@ The <dfn method for=CookieStore>getAll(|options|)</dfn> method steps are:
 1. Let |url| be |settings|'s [=environment/creation URL=].
 1. If |options|["{{CookieStoreGetOptions/url}}"] is present, then run these steps:
     1. Let |parsed| be the result of [=basic URL parser|parsing=] |options|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
-    1. If [=/this=]'s [=/relevant global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url|,
+    1. If [=/this=]'s [=/relevant global object=] is a {{Window}} object and |parsed| does not [=url/equal=] |url| with [=url/equals/exclude fragments=] set to true,
         then return [=a promise rejected with=] a {{TypeError}}.
     1. If |parsed|'s [=url/origin=] and |url|'s [=url/origin=] are not the [=same origin=],
         then return [=a promise rejected with=] a {{TypeError}}.


### PR DESCRIPTION
Per https://github.com/WICG/cookie-store/issues/266 specify that URL equivalence should be determined with [exclude fragments](https://url.spec.whatwg.org/#url-equals-exclude-fragments) set to true for cookieStore.get/getAll(_options_). 

The WPT for this are available [here](https://github.com/web-platform-tests/wpt/commit/615902259d23d8b16eaec60996f80c9a9ae7d5e4)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aamuley/cookie-store/pull/267.html" title="Last updated on Jul 14, 2025, 3:50 PM UTC (bbbc523)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/cookie-store/267/a6b7cfe...aamuley:bbbc523.html" title="Last updated on Jul 14, 2025, 3:50 PM UTC (bbbc523)">Diff</a>