### PR TITLE
Editorial: correct casing of headings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,7 +142,7 @@ cookieStore.set(
 ```
 </div>
 
-This also has the advantage of not relying on document and not blocking, which together make it usable from [[Service-Workers|Service Workers]], which otherwise do not have cookie access from script.
+This also has the advantage of not relying on document and not blocking, which together make it usable from [=service workers=], which otherwise do not have cookie access from script.
 
 This standard also includes a power-efficient monitoring API to replace `setTimeout`-based polling cookie monitors with cookie change observers.
 
@@ -161,7 +161,7 @@ In short, this API offers the following functionality:
         * ... for script-supplied in-scope request paths in [[Service-Workers|service worker]] contexts
 
 <!-- ============================================================ -->
-## Querying Cookies ## {#intro-query}
+## Querying cookies ## {#intro-query}
 <!-- ============================================================ -->
 
 Both [=documents=] and [=service workers=] access the same query API, via the
@@ -246,7 +246,7 @@ if (cookie.secure)
 
 
 <!-- ============================================================ -->
-## Modifying Cookies ## {#intro-modify}
+## Modifying cookies ## {#intro-modify}
 <!-- ============================================================ -->
 
 Both [=documents=] and [=service workers=] access the same modification API, via the
@@ -315,7 +315,7 @@ try {
 
 
 <!-- ============================================================ -->
-## Monitoring Cookies ## {#intro-monitor}
+## Monitoring cookies ## {#intro-monitor}
 <!-- ============================================================ -->
 
 To avoid polling, it is possible to observe changes to cookies.
@@ -432,7 +432,7 @@ A cookie is also subject to certain size limits. Per [[RFC6265BIS-14#name-storag
 <p class=note>[=Cookie=] attribute-values are stored as [=byte sequences=], not strings.
 
 <!-- ============================================================ -->
-## Cookie Store ## {#cookie-store--concept}
+## Cookie store ## {#cookie-store--concept}
 <!-- ============================================================ -->
 
 A <dfn>cookie store</dfn> is normatively defined for user agents by [[RFC6265BIS-14#name-user-agent-requirements|Cookies § User Agent Requirements]].
@@ -444,7 +444,7 @@ When any of the following conditions occur for a [=cookie store=], perform the s
 * A user agent removes excess [=cookies=] from the [=cookie store=].
 
 <!-- ============================================================ -->
-## Extensions to Service Worker ## {#service-worker-extensions}
+## Extensions to Service Workers ## {#service-worker-extensions}
 <!-- ============================================================ -->
 
 [[Service-Workers]] defines [=service worker registration=], which this specification extends.
@@ -457,7 +457,7 @@ a [=tuple=] of <dfn>name</dfn> and <dfn>url</dfn>.
 
 
 <!-- ============================================================ -->
-# The {{CookieStore}} Interface # {#CookieStore}
+# The {{CookieStore}} interface # {#CookieStore}
 <!-- ============================================================ -->
 
 <xmp class=idl>
@@ -766,7 +766,7 @@ The <dfn method for=CookieStore>delete(|options|)</dfn> method steps are:
 
 
 <!-- ============================================================ -->
-# The {{CookieStoreManager}} Interface # {#CookieStoreManager}
+# The {{CookieStoreManager}} interface # {#CookieStoreManager}
 <!-- ============================================================ -->
 
 A {{CookieStoreManager}} has an associated <dfn for=CookieStoreManager>registration</dfn> which is a [=service worker registration=].
@@ -912,7 +912,7 @@ navigator.serviceWorker.register('sw.js').then(registration => {
 
 
 <!-- ============================================================ -->
-# Event Interfaces # {#event-interfaces}
+# Event interfaces # {#event-interfaces}
 <!-- ============================================================ -->
 
 <!-- ============================================================ -->
@@ -966,7 +966,7 @@ dictionary ExtendableCookieChangeEventInit : ExtendableEventInit {
 The {{ExtendableCookieChangeEvent/changed}} and {{ExtendableCookieChangeEvent/deleted}} attributes must return the value they were initialized to.
 
 <!-- ============================================================ -->
-# Global Interfaces # {#globals}
+# Global interfaces # {#globals}
 <!-- ============================================================ -->
 
 A {{CookieStore}} is accessed by script using an attribute in the global
@@ -1027,7 +1027,7 @@ and return a [=byte sequence=] corresponding to the closest `cookie-date` repres
 
 
 <!-- ============================================================ -->
-## Query Cookies ## {#query-cookies-algorithm}
+## Query cookies ## {#query-cookies-algorithm}
 <!-- ============================================================ -->
 
 <div algorithm>
@@ -1098,7 +1098,7 @@ attributes are not exposed to script.
 </div>
 
 <!-- ============================================================ -->
-## Set a Cookie ## {#set-cookie-algorithm}
+## Set a cookie ## {#set-cookie-algorithm}
 <!-- ============================================================ -->
 
 <div algorithm>
@@ -1173,7 +1173,7 @@ run the following steps:
 
 
 <!-- ============================================================ -->
-## Delete a Cookie ## {#delete-cookie-algorithm}
+## Delete a cookie ## {#delete-cookie-algorithm}
 <!-- ============================================================ -->
 
 <div algorithm>
@@ -1214,7 +1214,7 @@ run the following steps:
 
 
 <!-- ============================================================ -->
-## Process Changes ## {#process-changes}
+## Process changes ## {#process-changes}
 <!-- ============================================================ -->
 
 <div algorithm>
@@ -1301,7 +1301,7 @@ To <dfn>prepare lists</dfn> from |changes|, run the following steps:
 
 
 <!-- ============================================================ -->
-# Security Considerations # {#security}
+# Security considerations # {#security}
 <!-- ============================================================ -->
 
 Other than cookie access from service worker contexts, this API is not intended to expose any new capabilities to the web.


### PR DESCRIPTION
We use sentence case for headings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookiestore/272.html" title="Last updated on Jul 28, 2025, 1:25 PM UTC (b948349)">Preview</a> | <a href="https://whatpr.org/cookiestore/272/5f9275a...b948349.html" title="Last updated on Jul 28, 2025, 1:25 PM UTC (b948349)">Diff</a>