### PR TITLE
Editorial: modernize algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1089,7 +1089,7 @@ To <dfn>set a cookie</dfn> given a [=/URL=] |url|,
     1. Let |encodedDomain| be the result of [=UTF-8 encode|UTF-8 encoding=] |parsedDomain|.
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] (\``Domain`\`, |encodedDomain|) to |attributes|.
-1. If |expires| is non-null, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
+1. If |expires| is non-null, then [=list/append=] (\``Expires`\`, |expires| ([=date serialized=])) to |attributes|.
 1. If |path| is the empty string, then set |path| to the [=/serialized cookie default path=] of |url|.
 1. If |path| does not start with U+002F (/), then return failure.
 1. If |path| is not U+002F (/), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.


### PR DESCRIPTION
Declare types, stop using / for two-tuples, and use syntax for lists.

Fixes #222.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookiestore/288.html" title="Last updated on Aug 18, 2025, 3:44 PM UTC (166cb5a)">Preview</a> | <a href="https://whatpr.org/cookiestore/288/b4cafb5...166cb5a.html" title="Last updated on Aug 18, 2025, 3:44 PM UTC (166cb5a)">Diff</a>