### PR TITLE
make cookie subscription name optional, url default to service worker…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -795,8 +795,10 @@ The <dfn method for=CookieStoreManager>subscribe(|subscriptions|)</dfn> method s
             1. Set |name| to |entry|["{{CookieStoreGetOptions/name}}"].
             1. [=Normalize=] |name|.
         1. Let |url| be |registration|'s [=service worker registration/scope url=].
-        1. If |entry|["{{CookieStoreGetOptions/url}}"] [=map/exists=], then set |url| to the result of [=basic URL parser|parsing=] |entry|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
-        1. If |url| is failure or if |url| does not [=string/start with=] |registration|'s [=service worker registration/scope url=], then [=reject=] |p| with a {{TypeError}} and abort these steps.
+        1. If |entry|["{{CookieStoreGetOptions/url}}"] [=map/exists=],
+            then set |url| to the result of [=basic URL parser|parsing=] |entry|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
+        1. If |url| is failure or |url| does not [=string/start with=] with |registration|'s [=service worker registration/scope url=],
+            then [=reject=] |p| with a {{TypeError}} and abort these steps.
         1. Let |subscription| be the [=cookie change subscription=] (|name|, |url|).
         1. If |subscription list| does not already [=list/contain=] |subscription|, then [=list/append=] |subscription| to |subscription list|.
     1. [=/Resolve=] |p| with undefined.
@@ -854,8 +856,10 @@ The <dfn method for=CookieStoreManager>unsubscribe(|subscriptions|)</dfn> method
             1. Set |name| to |entry|["{{CookieStoreGetOptions/name}}"].
             1. [=Normalize=] |name|.
         1. Let |url| be |registration|'s [=service worker registration/scope url=].
-        1. If |entry|["{{CookieStoreGetOptions/url}}"] [=map/exists=], then set |url| to the result of [=basic URL parser|parsing=] |entry|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
-        1. If |url| is failure or |url| does not [=string/start with=] |registration|'s [=service worker registration/scope url=], then [=reject=] |p| with a {{TypeError}} and abort these steps.
+        1. If |entry|["{{CookieStoreGetOptions/url}}"] [=map/exists=],
+            then set |url| to the result of [=basic URL parser|parsing=] |entry|["{{CookieStoreGetOptions/url}}"] with |settings|'s [=environment settings object/API base URL=].
+        1. If |url| is failure or |url| does not [=string/start with=] |registration|'s [=service worker registration/scope url=],
+            then [=reject=] |p| with a {{TypeError}} and abort these steps.
         1. Let |subscription| be the [=cookie change subscription=] (|name|, |url|).
         1. [=list/Remove=] any [=list/item=] from |subscription list| equal to |subscription|.
     1. [=/Resolve=] |p| with undefined.


### PR DESCRIPTION
… scope

<!--
Thank you for contributing to the Cookie Store API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

To fix mdn/mdn#284 and mdn/mdn#236 make the name optional and match to every available cookie in the service worker scope if it is not provided as an argument. The url of the subscription should default to be the service worker's scope url if omitted

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Webkit? (@annevk?)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/cookiestore/cookieStore_subscribe_arguments.https.any.js
   * https://github.com/web-platform-tests/wpt/pull/56004
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/43382
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookie-store/291.html" title="Last updated on Jan 6, 2026, 4:52 PM UTC (de819dd)">Preview</a> | <a href="https://whatpr.org/cookiestore/291/7ccd2e9...de819dd.html" title="Last updated on Jan 6, 2026, 4:52 PM UTC (de819dd)">Diff</a>