### PR TITLE
Allow setting a maxAge 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1134,7 +1134,6 @@ a [=/URL=] |url|,
 [=/scalar value string=] |path|, and
 [=/boolean=] |partitioned|:
 
-1. Let |maxAge| be 0.
 1. [=Normalize=] |name|.
 1. Let |value| be the empty string.
 1. If |name|'s [=string/length=] is 0, then set |value| to any non-empty [=implementation-defined=] string.
@@ -1146,8 +1145,8 @@ a [=/URL=] |url|,
     |domain|,
     |path|,
     "{{CookieSameSite/strict}}",
-    |partitioned|, and
-    |maxAge|.
+    |partitioned|,
+    and 0.
 
 </div>
 


### PR DESCRIPTION
Add `maxAge` as a CookieInitOption used in cookieStore.set(options). 
Related to #57 #162 

<!--
Thank you for contributing to the Cookie Store API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/commit/0f2fc4681c9c743dac1fb2b0a1b60669c262781f 
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: [issue](https://issues.chromium.org/430926231)
   * Gecko: [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=2004058)
   * WebKit: [bug](https://bugs.webkit.org/show_bug.cgi?id=303549)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/775
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookie-store/292.html" title="Last updated on Dec 4, 2025, 4:00 PM UTC (d0b4b70)">Preview</a> | <a href="https://whatpr.org/cookiestore/292/7676068...d0b4b70.html" title="Last updated on Dec 4, 2025, 4:00 PM UTC (d0b4b70)">Diff</a>