### PR TITLE
Fix Bikeshed API endpoint in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy
 
 remote: index.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output index.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
 	                       -F die-on=warning \
 	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
-	                       -F file=@index.bs) && \
+	                       -F file=@index.bs \
+	                       -F type=bikeshed-spec \
+	                       -F output=html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat index.html; echo ""; \
 		rm -f index.html; \


### PR DESCRIPTION
The `api.csswg.org/bikeshed/` endpoint is no longer reliable. Migrate to `www.w3.org/publications/spec-generator/` with the required `type=bikeshed-spec` and `output=html` parameters.

See https://github.com/w3c/spec-prod/issues/227#issuecomment-4049021313