### PR TITLE
Set navigation conditions potentially changed when setting cookie

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,6 +29,8 @@ Level: 1
 spec: ecma262; urlPrefix: https://tc39.github.io/ecma262/
     type: dfn; text: time values; url: sec-time-values-and-time-range
     type: dfn; text: ToString; url: sec-tostring
+spec: html; urlPrefix: https://html.spec.whatwg.org/
+    type: dfn; text: navigation conditions potentially changed; url: #navigation-conditions-potentially-changed
 </pre>
 
 <pre class=link-defaults>
@@ -653,6 +655,10 @@ The <dfn method for=CookieStore>set(|name|, |value|)</dfn> method steps are:
 1. If |origin| is an [=opaque origin=], then return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 1. Let |url| be |settings|'s [=environment/creation URL=].
 1. Let |p| be [=a new promise=].
+1. Let |global| be [=/this=]'s [=/relevant global object=].
+1. If the |global| is a {{Window}} object:
+    1. Let |navigable| be |global|'s [=associated Document=]'s [=node navigable=].
+    1. If |navigable| is non-null, then set |navigable|'s [=navigation conditions potentially changed=] to true.
 1. Run the following steps [=in parallel=]:
     1. Let |r| be the result of running [=set a cookie=] with
         |url|,


### PR DESCRIPTION
<!--
Thank you for contributing to the Cookie Store API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

This PR updates the spec to integrate with the new `navigation conditions potentially changed` concept introduced in https://github.com/whatwg/html/pull/11765.

- [x] At least two implementers are interested (and none opposed):
   * Chromium (https://github.com/whatwg/html/issues/11743)
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/5856811
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/366060351
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookiestore/302.html" title="Last updated on Aug 4, 2026, 4:33 AM UTC (9b8ca08)">Preview</a> | <a href="https://whatpr.org/cookiestore/302/54559c0...9b8ca08.html" title="Last updated on Aug 4, 2026, 4:33 AM UTC (9b8ca08)">Diff</a>